### PR TITLE
Feat/#20 SMNavigationView, NavigationRouter 구현

### DIFF
--- a/SantaManito-iOS/SantaManito-iOS.xcodeproj/project.pbxproj
+++ b/SantaManito-iOS/SantaManito-iOS.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		877EA2442C88AE750073FFBD /* DTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877EA2432C88AE750073FFBD /* DTO.swift */; };
 		879829052C9827B200A863EC /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 879829042C9827B200A863EC /* HomeViewModel.swift */; };
 		879829072C98284B00A863EC /* RoomService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 879829062C98284B00A863EC /* RoomService.swift */; };
+		879829092C9EA54B00A863EC /* BaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 879829082C9EA54B00A863EC /* BaseView.swift */; };
+		87C06E5A2C9EA5FE00F03637 /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C06E592C9EA5FE00F03637 /* Device.swift */; };
 		87D797A42C9454BF003BA602 /* OnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D797A32C9454BF003BA602 /* OnboardingViewModel.swift */; };
 		D22E9B592C88031A00086549 /* SantaManito_iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22E9B582C88031A00086549 /* SantaManito_iOSApp.swift */; };
 		D22E9B5B2C88031A00086549 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22E9B5A2C88031A00086549 /* HomeView.swift */; };
@@ -83,6 +85,8 @@
 		877EA2432C88AE750073FFBD /* DTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DTO.swift; sourceTree = "<group>"; };
 		879829042C9827B200A863EC /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		879829062C98284B00A863EC /* RoomService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomService.swift; sourceTree = "<group>"; };
+		879829082C9EA54B00A863EC /* BaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseView.swift; sourceTree = "<group>"; };
+		87C06E592C9EA5FE00F03637 /* Device.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Device.swift; sourceTree = "<group>"; };
 		87D797A32C9454BF003BA602 /* OnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
 		D22E9B552C88031A00086549 /* SantaManito-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SantaManito-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D22E9B582C88031A00086549 /* SantaManito_iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SantaManito_iOSApp.swift; sourceTree = "<group>"; };
@@ -135,6 +139,7 @@
 				877CA0722C8C4C5C00D23193 /* SMView.swift */,
 				877CA0802C8C555C00D23193 /* SMScrollView.swift */,
 				877CA0822C8CA75C00D23193 /* SMAlertView.swift */,
+				879829082C9EA54B00A863EC /* BaseView.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -262,6 +267,7 @@
 			children = (
 				877CA07D2C8C50D000D23193 /* View */,
 				D22E9B6A2C8803C100086549 /* Util.swift */,
+				87C06E592C9EA5FE00F03637 /* Device.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -517,10 +523,12 @@
 				D2BC1A902C8F4C6400CB32B8 /* Date+.swift in Sources */,
 				D22E9B732C8803E500086549 /* Service.swift in Sources */,
 				877EA23F2C88AB930073FFBD /* AuthService.swift in Sources */,
+				879829092C9EA54B00A863EC /* BaseView.swift in Sources */,
 				D2BC1A922C90101E00CB32B8 /* EditMissionView.swift in Sources */,
 				D22E9B592C88031A00086549 /* SantaManito_iOSApp.swift in Sources */,
 				D25570ED2C8E85CB00CCC226 /* EditRoomInfoViewModel.swift in Sources */,
 				877EA2322C889DCB0073FFBD /* ButtonStyles.swift in Sources */,
+				87C06E5A2C9EA5FE00F03637 /* Device.swift in Sources */,
 				877CA07F2C8C50DC00D23193 /* Corner.swift in Sources */,
 				877CA0732C8C4C5C00D23193 /* SMView.swift in Sources */,
 				D2BC1AA32C90A29200CB32B8 /* CheckRoomInfoViewModel.swift in Sources */,

--- a/SantaManito-iOS/SantaManito-iOS.xcodeproj/project.pbxproj
+++ b/SantaManito-iOS/SantaManito-iOS.xcodeproj/project.pbxproj
@@ -31,12 +31,15 @@
 		879829072C98284B00A863EC /* RoomService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 879829062C98284B00A863EC /* RoomService.swift */; };
 		879829092C9EA54B00A863EC /* BaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 879829082C9EA54B00A863EC /* BaseView.swift */; };
 		87C06E5A2C9EA5FE00F03637 /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C06E592C9EA5FE00F03637 /* Device.swift */; };
+		87C06E5D2C9EAB6800F03637 /* NaivgationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C06E5C2C9EAB6800F03637 /* NaivgationRouter.swift */; };
+		87C06E5F2C9EADD600F03637 /* NavigationRoutingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C06E5E2C9EADD600F03637 /* NavigationRoutingView.swift */; };
+		87C06E612C9EADE700F03637 /* NavigationDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C06E602C9EADE700F03637 /* NavigationDestination.swift */; };
 		87D797A42C9454BF003BA602 /* OnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D797A32C9454BF003BA602 /* OnboardingViewModel.swift */; };
 		D22E9B592C88031A00086549 /* SantaManito_iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22E9B582C88031A00086549 /* SantaManito_iOSApp.swift */; };
 		D22E9B5B2C88031A00086549 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22E9B5A2C88031A00086549 /* HomeView.swift */; };
 		D22E9B5D2C88031C00086549 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D22E9B5C2C88031C00086549 /* Assets.xcassets */; };
 		D22E9B602C88031C00086549 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D22E9B5F2C88031C00086549 /* Preview Assets.xcassets */; };
-		D22E9B6B2C8803C100086549 /* Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22E9B6A2C8803C100086549 /* Util.swift */; };
+		D22E9B6B2C8803C100086549 /* ObservableObjectSettable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22E9B6A2C8803C100086549 /* ObservableObjectSettable.swift */; };
 		D22E9B6D2C8803C800086549 /* Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22E9B6C2C8803C800086549 /* Extension.swift */; };
 		D22E9B732C8803E500086549 /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22E9B722C8803E500086549 /* Service.swift */; };
 		D22E9B752C8803EC00086549 /* Provider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22E9B742C8803EC00086549 /* Provider.swift */; };
@@ -87,13 +90,16 @@
 		879829062C98284B00A863EC /* RoomService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomService.swift; sourceTree = "<group>"; };
 		879829082C9EA54B00A863EC /* BaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseView.swift; sourceTree = "<group>"; };
 		87C06E592C9EA5FE00F03637 /* Device.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Device.swift; sourceTree = "<group>"; };
+		87C06E5C2C9EAB6800F03637 /* NaivgationRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NaivgationRouter.swift; sourceTree = "<group>"; };
+		87C06E5E2C9EADD600F03637 /* NavigationRoutingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationRoutingView.swift; sourceTree = "<group>"; };
+		87C06E602C9EADE700F03637 /* NavigationDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationDestination.swift; sourceTree = "<group>"; };
 		87D797A32C9454BF003BA602 /* OnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
 		D22E9B552C88031A00086549 /* SantaManito-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SantaManito-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D22E9B582C88031A00086549 /* SantaManito_iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SantaManito_iOSApp.swift; sourceTree = "<group>"; };
 		D22E9B5A2C88031A00086549 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		D22E9B5C2C88031C00086549 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		D22E9B5F2C88031C00086549 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
-		D22E9B6A2C8803C100086549 /* Util.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Util.swift; sourceTree = "<group>"; };
+		D22E9B6A2C8803C100086549 /* ObservableObjectSettable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableObjectSettable.swift; sourceTree = "<group>"; };
 		D22E9B6C2C8803C800086549 /* Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extension.swift; sourceTree = "<group>"; };
 		D22E9B722C8803E500086549 /* Service.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Service.swift; sourceTree = "<group>"; };
 		D22E9B742C8803EC00086549 /* Provider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Provider.swift; sourceTree = "<group>"; };
@@ -197,6 +203,16 @@
 			path = DTO;
 			sourceTree = "<group>";
 		};
+		87C06E5B2C9EAB5E00F03637 /* Navigation */ = {
+			isa = PBXGroup;
+			children = (
+				87C06E5C2C9EAB6800F03637 /* NaivgationRouter.swift */,
+				87C06E602C9EADE700F03637 /* NavigationDestination.swift */,
+				87C06E5E2C9EADD600F03637 /* NavigationRoutingView.swift */,
+			);
+			path = Navigation;
+			sourceTree = "<group>";
+		};
 		D22E9B4C2C88031A00086549 = {
 			isa = PBXGroup;
 			children = (
@@ -238,6 +254,7 @@
 		D22E9B662C8803A200086549 /* App */ = {
 			isa = PBXGroup;
 			children = (
+				87C06E5B2C9EAB5E00F03637 /* Navigation */,
 				D22E9B582C88031A00086549 /* SantaManito_iOSApp.swift */,
 				877EA23A2C88AAC10073FFBD /* DIContainer.swift */,
 			);
@@ -266,7 +283,7 @@
 			isa = PBXGroup;
 			children = (
 				877CA07D2C8C50D000D23193 /* View */,
-				D22E9B6A2C8803C100086549 /* Util.swift */,
+				D22E9B6A2C8803C100086549 /* ObservableObjectSettable.swift */,
 				87C06E592C9EA5FE00F03637 /* Device.swift */,
 			);
 			path = Util;
@@ -509,12 +526,13 @@
 			files = (
 				D2BC1AA12C90A26B00CB32B8 /* CheckRoomInfoView.swift in Sources */,
 				D2BC1A9C2C90473100CB32B8 /* Mission.swift in Sources */,
+				87C06E5D2C9EAB6800F03637 /* NaivgationRouter.swift in Sources */,
 				D2BC1A8C2C8EBCF500CB32B8 /* SMColoredTextView.swift in Sources */,
 				877CA0A42C94305200D23193 /* SplashViewModel.swift in Sources */,
 				D22E9B5B2C88031A00086549 /* HomeView.swift in Sources */,
 				877CA0A62C94305A00D23193 /* CancelBag.swift in Sources */,
 				877EA23B2C88AAC10073FFBD /* DIContainer.swift in Sources */,
-				D22E9B6B2C8803C100086549 /* Util.swift in Sources */,
+				D22E9B6B2C8803C100086549 /* ObservableObjectSettable.swift in Sources */,
 				D22E9B772C8803F100086549 /* Entity.swift in Sources */,
 				87D797A42C9454BF003BA602 /* OnboardingViewModel.swift in Sources */,
 				877CA0712C8AB3DE00D23193 /* LoadingView.swift in Sources */,
@@ -531,12 +549,14 @@
 				87C06E5A2C9EA5FE00F03637 /* Device.swift in Sources */,
 				877CA07F2C8C50DC00D23193 /* Corner.swift in Sources */,
 				877CA0732C8C4C5C00D23193 /* SMView.swift in Sources */,
+				87C06E5F2C9EADD600F03637 /* NavigationRoutingView.swift in Sources */,
 				D2BC1AA32C90A29200CB32B8 /* CheckRoomInfoViewModel.swift in Sources */,
 				877EA2442C88AE750073FFBD /* DTO.swift in Sources */,
 				877EA23D2C88AB8D0073FFBD /* UserService.swift in Sources */,
 				877EA2412C88ABA00073FFBD /* PushNotificationService.swift in Sources */,
 				D25570E92C8E858A00CCC226 /* EditRoomInfoView.swift in Sources */,
 				D26BFA802C91692700C5CF86 /* SMInfoView.swift in Sources */,
+				87C06E612C9EADE700F03637 /* NavigationDestination.swift in Sources */,
 				D26BFA8E2C91987900C5CF86 /* EnterRoomViewModel.swift in Sources */,
 				D276B6082C8AB64B00230FA2 /* Font.swift in Sources */,
 				D26BFA932C919D0900C5CF86 /* ManitoRoomViewModel.swift in Sources */,

--- a/SantaManito-iOS/SantaManito-iOS/App/DIContainer.swift
+++ b/SantaManito-iOS/SantaManito-iOS/App/DIContainer.swift
@@ -7,13 +7,20 @@
 
 import Foundation
 
+typealias NavigationRoutableType = NavigationRoutable & ObservableObjectSettable
+
 class DIContainer: ObservableObject {
-  
-  var service: ServiceType
-  
-  init(
-    service: ServiceType
-  ) {
-    self.service = service
-  }
+    
+    var service: ServiceType
+    var navigationRouter: NavigationRoutable & ObservableObjectSettable
+    
+    init(
+        service: ServiceType,
+        navigationRouter: NavigationRoutable & ObservableObjectSettable = NavigationRouter()
+    ) {
+        self.service = service
+        self.navigationRouter = navigationRouter
+        
+        navigationRouter.setObjectWillChange(objectWillChange)
+    }
 }

--- a/SantaManito-iOS/SantaManito-iOS/App/Navigation/NaivgationRouter.swift
+++ b/SantaManito-iOS/SantaManito-iOS/App/Navigation/NaivgationRouter.swift
@@ -1,0 +1,44 @@
+//
+//  NaivgationRouter.swift
+//  SantaManito-iOS
+//
+//  Created by 장석우 on 9/21/24.
+//
+
+import Foundation
+import Combine
+
+protocol NavigationRoutable {
+  var destinations: [NavigationDestination] { get set }
+  
+  func push(to view: NavigationDestination)
+  func pop()
+  func popToRootView()
+}
+
+
+class NavigationRouter: NavigationRoutable, ObservableObjectSettable {
+  
+  var objectWillChange: ObservableObjectPublisher?
+  
+  var destinations: [NavigationDestination] = [] {
+    didSet {
+      objectWillChange?.send()
+    }
+  }
+  
+  func push(to view: NavigationDestination) {
+    destinations.append(view)
+  }
+  
+  func pop() {
+    _ = destinations.popLast()
+  }
+  
+  func popToRootView() {
+    destinations = []
+  }
+  
+  
+}
+

--- a/SantaManito-iOS/SantaManito-iOS/App/Navigation/NavigationDestination.swift
+++ b/SantaManito-iOS/SantaManito-iOS/App/Navigation/NavigationDestination.swift
@@ -1,0 +1,16 @@
+//
+//  NavigationType.swift
+//  SantaManito-iOS
+//
+//  Created by 장석우 on 9/21/24.
+//
+
+import Foundation
+
+enum NavigationDestination: Hashable {
+    
+    case editRoom(viewType: ViewType)
+    case enterRoom
+    case roomInfo
+    case myPage
+}

--- a/SantaManito-iOS/SantaManito-iOS/App/Navigation/NavigationRoutingView.swift
+++ b/SantaManito-iOS/SantaManito-iOS/App/Navigation/NavigationRoutingView.swift
@@ -26,3 +26,15 @@ struct NavigationRoutingView: View {
         }
     }
 }
+
+
+extension View {
+    
+    func setSMNavigation() -> some View {
+        self.navigationDestination(for: NavigationDestination.self) { destination in
+            return NavigationRoutingView(destination: destination)
+        }
+    }
+    
+
+}

--- a/SantaManito-iOS/SantaManito-iOS/App/Navigation/NavigationRoutingView.swift
+++ b/SantaManito-iOS/SantaManito-iOS/App/Navigation/NavigationRoutingView.swift
@@ -1,0 +1,28 @@
+//
+//  NavigationRoutingView.swift
+//  SantaManito-iOS
+//
+//  Created by 장석우 on 9/21/24.
+//
+
+import Foundation
+import SwiftUI
+
+struct NavigationRoutingView: View {
+  
+  @EnvironmentObject var container: DIContainer
+  @State var destination: NavigationDestination
+  
+    var body: some View {
+        switch destination {
+        case let .editRoom(viewType):
+            EditRoomInfoView(viewModel: .init(viewType: viewType))
+        case .enterRoom:
+            EnterRoomView(viewModel: .init())
+        case .roomInfo:
+            CheckRoomInfoView(viewModel: .init())
+        case .myPage:
+            Text("마이페이지")
+        }
+    }
+}

--- a/SantaManito-iOS/SantaManito-iOS/Core/Util/Device.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Core/Util/Device.swift
@@ -1,0 +1,97 @@
+//
+//  Device.swift
+//  SantaManito-iOS
+//
+//  Created by 장석우 on 9/21/24.
+//
+
+import UIKit
+
+// MARK: 디바이스의 크기, 여백 등의 정보를 담은 struct
+// 참고하면 좋은 사이트 : https://kapeli.com/cheat_sheets/iOS_Design.docset/Contents/Resources/Documents/index
+struct Device {
+    
+    private static var currentWindow: UIWindow? {
+        return UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first?.windows.first { $0.isKeyWindow }
+    }
+    
+    // MARK: 현재 활성화된 window scene 가져오기
+    private static var currentWindowScene: UIWindowScene? {
+        return UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first
+    }
+    
+    
+    // MARK: 디바이스 width
+    static var width: CGFloat {
+        return UIScreen.main.bounds.width
+    }
+    
+    // MARK: 디바이스 height
+    static var height: CGFloat {
+        return UIScreen.main.bounds.height
+    }
+    
+    // MARK: 노치 디자인인지 아닌지
+    static var isNotch: Bool {
+        return Double(currentWindow?.safeAreaInsets.bottom ?? -1) > 0
+    }
+    
+    // MARK: 상태바 높이
+    static var statusBarHeight: CGFloat {
+        return currentWindowScene?.statusBarManager?.statusBarFrame.height ?? 0
+    }
+    
+    // MARK: 네비게이션 바 높이
+    static var navigationBarHeight: CGFloat {
+        return UINavigationController().navigationBar.frame.height
+    }
+    
+    // MARK: 탭 바 높이
+    static var tabBarHeight: CGFloat {
+        return UITabBarController().tabBar.frame.height
+    }
+    
+    // MARK: 키보드 높이
+    static var keyBoardHeight: CGFloat = 0
+    
+    // MARK: 디바이스의 위쪽 여백 (Safe Area 위쪽 여백)
+    // ** 위쪽 여백의 전체 높이 : topInset + statusBarHeight + navigationBarHeight(존재하는 경우) **
+    static var topInset: CGFloat {
+        return currentWindow?.safeAreaInsets.top ?? 0
+    }
+    
+    // MARK: 디바이스의 아래쪽 여백 (Safe Area 아래쪽 여백)
+    // ** 아래쪽 여백의 전체 높이 : bottomInset + tabBarHeight(존재하는 경우) **
+    static var bottomInset: CGFloat {
+        return currentWindow?.safeAreaInsets.bottom ?? 0
+    }
+    
+    static var osVersion: String {
+        return UIDevice.current.systemVersion
+    }
+    
+    static func getDeviceIdentifier() -> String {
+        var systemInfo = utsname()
+        uname(&systemInfo)
+        let machineMirror = Mirror(reflecting: systemInfo.machine)
+        let identifier = machineMirror.children.reduce("") { identifier, element in
+            guard let value = element.value as? Int8, value != 0 else { return identifier }
+            return identifier + String(UnicodeScalar(UInt8(value)))
+        }
+        
+        return identifier
+    }
+    
+    // 현재 버전 가져오기
+    static func getCurrentVersion() -> String {
+        guard let dictionary = Bundle.main.infoDictionary,
+              let version = dictionary["CFBundleShortVersionString"] as? String else { return "" }
+        return version
+    }
+}
+
+

--- a/SantaManito-iOS/SantaManito-iOS/Core/Util/ObservableObjectSettable.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Core/Util/ObservableObjectSettable.swift
@@ -1,0 +1,19 @@
+//
+//  Util.swift
+//  SantaManito-iOS
+//
+//  Created by 류희재 on 9/4/24.
+//
+
+import Combine
+
+protocol ObservableObjectSettable: AnyObject {
+  var objectWillChange: ObservableObjectPublisher? { get set }
+  func setObjectWillChange(_ objectWillChange: ObservableObjectPublisher?)
+}
+
+extension ObservableObjectSettable {
+  func setObjectWillChange(_ objectWillChange: ObservableObjectPublisher?) {
+    self.objectWillChange = objectWillChange
+  }
+}

--- a/SantaManito-iOS/SantaManito-iOS/Core/Util/Util.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Core/Util/Util.swift
@@ -1,8 +1,0 @@
-//
-//  Util.swift
-//  SantaManito-iOS
-//
-//  Created by 류희재 on 9/4/24.
-//
-
-import Foundation

--- a/SantaManito-iOS/SantaManito-iOS/DSKit/Component/BaseView.swift
+++ b/SantaManito-iOS/SantaManito-iOS/DSKit/Component/BaseView.swift
@@ -1,0 +1,45 @@
+//
+//  SMViewType.swift
+//  SantaManito-iOS
+//
+//  Created by 장석우 on 9/21/24.
+//
+
+import SwiftUI
+
+
+protocol BaseView: View {
+    
+    associatedtype TopView : View
+    associatedtype Content : View
+    
+    var padding: CGFloat { get }
+    @ViewBuilder var topView: Self.TopView { get }
+    @ViewBuilder var content: Self.Content { get}
+}
+
+extension BaseView {
+    
+    var padding: CGFloat { 0 }
+    
+    var body: some View {
+        
+        VStack(spacing: 0) {
+            ZStack {
+                Color.smNavy
+                
+                topView
+            }
+            .frame(height: 300)
+            .cornerRadius(20, corners: [.bottomLeft, .bottomRight])
+            
+            
+            content
+                .padding(.top, 0)
+            
+            Spacer()
+        }
+        .ignoresSafeArea(edges: .top)
+    }
+    
+}

--- a/SantaManito-iOS/SantaManito-iOS/DSKit/Component/BaseView.swift
+++ b/SantaManito-iOS/SantaManito-iOS/DSKit/Component/BaseView.swift
@@ -7,16 +7,19 @@
 
 import SwiftUI
 
-
 protocol BaseView: View {
     
+    associatedtype NavigationBar: View
     associatedtype TopView : View
     associatedtype Content : View
     
     var padding: CGFloat { get }
+    
+    @ViewBuilder var navigationBar: Self.NavigationBar { get }
     @ViewBuilder var topView: Self.TopView { get }
     @ViewBuilder var content: Self.Content { get}
 }
+
 
 extension BaseView {
     
@@ -29,6 +32,11 @@ extension BaseView {
                 Color.smNavy
                 
                 topView
+                
+                navigationBar
+                    .padding(.top, Device.topInset)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: Device.navigationBarHeight)
             }
             .frame(height: 300)
             .cornerRadius(20, corners: [.bottomLeft, .bottomRight])

--- a/SantaManito-iOS/SantaManito-iOS/DSKit/Component/SMScrollView.swift
+++ b/SantaManito-iOS/SantaManito-iOS/DSKit/Component/SMScrollView.swift
@@ -47,7 +47,9 @@ struct SMScrollView<TopView: View, Content: View>: View {
         .onDisappear {
             UIScrollView.appearance().bounces = true
         }
-        .ignoresSafeArea()
+        .ignoresSafeArea(edges: .top)
+        .navigationBarBackButtonHidden()
+        .setSMNavigation()
         
     }
 }

--- a/SantaManito-iOS/SantaManito-iOS/DSKit/Component/SMView.swift
+++ b/SantaManito-iOS/SantaManito-iOS/DSKit/Component/SMView.swift
@@ -40,6 +40,8 @@ struct SMView<TopView: View, Content: View>: View {
             Spacer()
         }
         .ignoresSafeArea(edges: .top)
+        .navigationBarBackButtonHidden()
+        .setSMNavigation()
         
     }
 }

--- a/SantaManito-iOS/SantaManito-iOS/Feature/EnterRoom/View/EnterRoomView.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/EnterRoom/View/EnterRoomView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct EnterRoomView: View {
     @StateObject var viewModel: EnterRoomViewModel
+    @EnvironmentObject var container: DIContainer
     
     var body: some View {
         VStack {
@@ -97,4 +98,5 @@ struct EnterRoomView: View {
 
 #Preview {
     EnterRoomView(viewModel: EnterRoomViewModel())
+        .environmentObject(DIContainer(service: StubService()))
 }

--- a/SantaManito-iOS/SantaManito-iOS/Feature/Home/HomeView.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/Home/HomeView.swift
@@ -9,112 +9,116 @@ import SwiftUI
 
 struct HomeView: View {
     
+    @EnvironmentObject var container: DIContainer
     @StateObject var viewModel: HomeViewModel
     
     var body: some View {
-        
-        SMView(padding: -140) {
+        NavigationStack(path: $container.navigationRouter.destinations) {
             
-            ZStack {
-                Image(.snow)
-                    .resizable()
-                    .scaledToFit()
-                    .padding(.horizontal, 40)
+            SMView(padding: -140) {
                 
-                
-                VStack {
-                    ZStack {
-                        Image(.logo)
-                            .resizable()
-                            .scaledToFit()
-                            .frame(height: 36)
-                        
-                        HStack {
-                            Spacer()
-                            Button {
-                                viewModel.send(.myPageButtonDidTap)
-                            } label: {
-                                Image(.btnMinus) //TODO: 사람 에셋으로 변경
-                                    .resizable()
-                                    .scaledToFit()
-                                    .frame(width: 42, height: 42)
-                            }
-                        }
-                    }
-                    .frame(height: 44)
-                    Spacer()
-                }
-                .padding(.top, 70)
-                .padding(.horizontal, 16)
-                
-            }
-        } content: {
-            VStack {
-                HStack(spacing: 20) {
-                    HomeButton(imageResource: .graphicsSantaNeck,
-                               title: "방 만들기",
-                               description: "새로운 산타\n 마니또 시작하기")
-                    {
-                        viewModel.send(.makeRoomButtonDidTap)
-                    }
+                ZStack {
+                    Image(.snow)
+                        .resizable()
+                        .scaledToFit()
+                        .padding(.horizontal, 40)
                     
-                    HomeButton(imageResource: .graphicsRudolphNeck,
-                               title: "방 입장하기",
-                               description: "새로운 산타\n 입장코드 입력하기")
-                    {
-                        viewModel.send(.joinRoomButtonDidTap)
-                    }
-                }
-                .padding(.horizontal, 40)
-                
-                HStack {
-                    Text("나의 산타 마니또")
-                        .font(.semibold_20)
-                        .foregroundStyle(.smBlack)
-                    Spacer()
-                    Button {
-                        viewModel.send(.refreshButtonDidTap)
-                    } label: {
-                        Image(systemName: "arrow.clockwise") // TODO: 에셋 변경
-                            .foregroundStyle(.gray)
-                    }
-                }
-                .padding(.top, 40)
-                .padding(.horizontal, 20)
-                
-                GeometryReader { proxy in
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack {
-                            ForEach(viewModel.state.rooms, id: \.id) { room in
-                                Button {
-                                    
-                                } label: {
-                                    HomeRoomCell(room, width: proxy.size.width / 2.4)
-                                }
-                                .buttonStyle(ScaleButtonStyle())
+                    
+                    VStack {
+                        ZStack {
+                            Image(.logo)
+                                .resizable()
+                                .scaledToFit()
+                                .frame(height: 36)
                             
-                                    
-                                
-                                Spacer().frame(width: 15)
+                            HStack {
+                                Spacer()
+                                Button {
+                                    viewModel.send(.myPageButtonDidTap)
+                                } label: {
+                                    Image(.btnMinus) //TODO: 사람 에셋으로 변경
+                                        .resizable()
+                                        .scaledToFit()
+                                        .frame(width: 42, height: 42)
+                                }
                             }
                         }
-                        .padding(.horizontal, 20)
+                        .frame(height: 44)
+                        Spacer()
                     }
+                    .padding(.top, 70)
+                    .padding(.horizontal, 16)
+                    
                 }
-                .padding(.top, 20)
-         
-                Spacer()
+            } content: {
+                VStack {
+                    HStack(spacing: 20) {
+                        HomeButton(imageResource: .graphicsSantaNeck,
+                                   title: "방 만들기",
+                                   description: "새로운 산타\n 마니또 시작하기")
+                        {
+                            viewModel.send(.makeRoomButtonDidTap)
+                        }
+                        
+                        HomeButton(imageResource: .graphicsRudolphNeck,
+                                   title: "방 입장하기",
+                                   description: "새로운 산타\n 입장코드 입력하기")
+                        {
+                            viewModel.send(.enterRoomButtonDidTap)
+                        }
+                    }
+                    .padding(.horizontal, 40)
+                    
+                    HStack {
+                        Text("나의 산타 마니또")
+                            .font(.semibold_20)
+                            .foregroundStyle(.smBlack)
+                        Spacer()
+                        Button {
+                            viewModel.send(.refreshButtonDidTap)
+                        } label: {
+                            Image(systemName: "arrow.clockwise") // TODO: 에셋 변경
+                                .foregroundStyle(.gray)
+                        }
+                    }
+                    .padding(.top, 40)
+                    .padding(.horizontal, 20)
+                    
+                    GeometryReader { proxy in
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack {
+                                ForEach(viewModel.state.rooms, id: \.id) { room in
+                                    Button {
+                                        
+                                    } label: {
+                                        HomeRoomCell(room, width: proxy.size.width / 2.4)
+                                    }
+                                    .buttonStyle(ScaleButtonStyle())
+                                    
+                                    
+                                    
+                                    Spacer().frame(width: 15)
+                                }
+                            }
+                            .padding(.horizontal, 20)
+                        }
+                    }
+                    .padding(.top, 20)
+                    
+                    Spacer()
+                }
+                
             }
-            
+            .onAppear {
+                viewModel.send(.onAppear)
+            }
         }
-        .onAppear {
-            viewModel.send(.onAppear)
-        }
+        
         
         
         
     }
-        
+    
 }
 
 
@@ -274,7 +278,7 @@ fileprivate struct HomeRoomStateChip: View {
     let state: RoomState
     var title: String {
         switch state {
-        case .notStarted: 
+        case .notStarted:
             "매칭 대기 중"
         case let .inProgress(deadline):
             "공개 \(deadline)일 전"
@@ -312,5 +316,7 @@ fileprivate struct HomeRoomStateChip: View {
 
 
 #Preview {
-    HomeView(viewModel: HomeViewModel(roomService: StubRoomService()))
+    let container = DIContainer(service: StubService())
+    return HomeView(viewModel: HomeViewModel(roomService: StubRoomService(), navigationRouter: container.navigationRouter))
+        .environmentObject(container)
 }

--- a/SantaManito-iOS/SantaManito-iOS/Feature/Home/HomeViewModel.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/Home/HomeViewModel.swift
@@ -16,28 +16,19 @@ class HomeViewModel: ObservableObject {
         case refreshButtonDidTap
         case myPageButtonDidTap
         case makeRoomButtonDidTap
-        case joinRoomButtonDidTap
+        case enterRoomButtonDidTap
         case roomCellDidTap
     }
     
     
     struct State {
-        
-        var desination: Destination = .none
         var rooms: [RoomInfo] = []
-        
-        enum Destination {
-            case none
-            case myPage
-            case makeRoom
-            case joinRoom
-            case room
-        }
     }
     
     //MARK: - Dependency
     
     var roomService: RoomServiceType
+    private var navigationRouter: NavigationRoutableType
     
     //MARK: - Properties
     
@@ -46,8 +37,12 @@ class HomeViewModel: ObservableObject {
 
     //MARK: - Init
     
-    init(roomService: RoomServiceType) {
+    init(
+        roomService: RoomServiceType,
+        navigationRouter: NavigationRoutableType
+    ) {
         self.roomService = roomService
+        self.navigationRouter = navigationRouter
     }
     
     //MARK: - Methods
@@ -66,17 +61,19 @@ class HomeViewModel: ObservableObject {
                 .store(in: cancelBag)
             
         case .myPageButtonDidTap:
-            break
+            navigationRouter.push(to: .myPage)
         
         case .makeRoomButtonDidTap:
-            break
+            navigationRouter.push(to: .editRoom(viewType: .createMode))
             
-        case .joinRoomButtonDidTap:
-            break
+        case .enterRoomButtonDidTap:
+            navigationRouter.push(to: .enterRoom)
+            
         case .refreshButtonDidTap:
             break
+            
         case .roomCellDidTap:
-            break
+            navigationRouter.push(to: .roomInfo)
         }
     }
 }

--- a/SantaManito-iOS/SantaManito-iOS/Feature/MakeRoom/View/Component/SMInfoView.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/MakeRoom/View/Component/SMInfoView.swift
@@ -19,6 +19,8 @@ struct SMInfoView: View {
     let title: String
     let description: String
     
+    @Environment(\.dismiss) var dismiss
+    
     init(title: String, description: String) {
         self.title = title
         self.description = description
@@ -31,6 +33,7 @@ struct SMInfoView: View {
                     .frame(height: 68)
                 
                 Button {
+                    dismiss() // @Environment dismiss 사용한 이유는 router pop 사용시 애니메이션이 부자연 스러움
                 } label: {
                     Image(.btnBack)
                 }

--- a/SantaManito-iOS/SantaManito-iOS/Feature/MakeRoom/View/EditRoomInfoView.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/MakeRoom/View/EditRoomInfoView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct EditRoomInfoView: View {
+    @EnvironmentObject var container: DIContainer
     @StateObject var viewModel: EditRoomInfoViewModel
 
     var body: some View {
@@ -43,6 +44,7 @@ struct EditRoomInfoView: View {
         .onAppear {
             viewModel.send(action: .load)
         }
+        .navigationBarBackButtonHidden()
     }
 }
 
@@ -243,7 +245,7 @@ fileprivate struct MakeRoomButtonView: View {
                     
                 }
                 .padding(.vertical, 17)
-                .frame(width: .infinity)
+                .frame(maxWidth: .infinity)
                 .background(viewModel.state.isEnabled ? .smDarkgray : .smLightgray)
                 .disabled(!viewModel.state.isEnabled)
                 .clipShape(RoundedRectangle(cornerRadius: 10))

--- a/SantaManito-iOS/SantaManito-iOS/Feature/MakeRoom/ViewModel/EditRoomInfoViewModel.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/MakeRoom/ViewModel/EditRoomInfoViewModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Combine
 
-enum ViewType {
+enum ViewType: Hashable {
     case createMode
     case editMode(Int, Date)
 

--- a/SantaManito-iOS/SantaManito-iOS/Feature/Splash/SplashView.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/Splash/SplashView.swift
@@ -22,7 +22,13 @@ struct SplashView: View {
                     viewModel.state.desination = .main
                 })
             )
-            case .main: HomeView(viewModel: HomeViewModel(roomService: container.service.roomService))
+            case .main:
+                HomeView(
+                viewModel: .init(
+                    roomService: container.service.roomService,
+                    navigationRouter: container.navigationRouter
+                )
+            )
             }
         }
         .onAppear {


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- closed #20

### ✅ 작업한 내용
- `enum` NavigationDestination
- `struct` NavigationRoutingView
- `class` NavigationRouter
- Navigation관련 로직 구현했습니다.


## 사용 법!!!!
### 구조
<img width="522" alt="스크린샷 2024-09-22 오전 1 15 21" src="https://github.com/user-attachments/assets/3b866ed5-772f-47ed-a31f-e6ee1f421c5d">
LMessenger를 참조했습니다. 

### FirstView위에 SecondView를 push하려면 어떻게 해야 하나요?
<img width="743" alt="스크린샷 2024-09-22 오전 1 16 36" src="https://github.com/user-attachments/assets/841260b3-c996-431a-aa34-b43fd4159a12">

**사전 작업**
1. FirstView에`@EnvironmentObject var container: DIContainer `를 선언한다. 
2. FirstViewModel에 container의 NavigationRouter를 생성자 주입한다. 

**구현 방법**
1. `enum` NavigationDestination에 second case를 추가한다.
2. FirstView에 body 내부에 `.setSMNavigation()`을 단다. (SMView에 구현되어 있어 추가로 구현할 필요 없음)
3. ViewModel에서 navigationRouter.append(NavigationDestination.second)를 한다.

### pop 하려면 어떻게 해야 하나요?
<img width="772" alt="스크린샷 2024-09-22 오전 1 18 08" src="https://github.com/user-attachments/assets/f959e3d3-8c7e-4f95-a28c-8d8e5c902151">

**구현 방법**
1. View에 `@Environment(\.dismiss) var dismiss` 를 선언한다 (SMInfoView엔 구현되어 있어 추가로 구현할 필요 없음)
2. View의 백버튼의 액션으로 dismiss()를 호출한다. (SMInfoView엔 구현되어 있어 추가로 구현할 필요 없음)

### ❗️PR Point
#### 1. `navigationRouter.pop()`이 아닌 `@Environment(\.dismiss)` 를 사용한 이유
iOS 17 업데이트 이후 부터 navigationBackButtonHidden() 처리 후 커스텀 백버튼으로 뒤로가기 실행시
아래와 같이 뒤로가기 버튼에서 흰색버튼이 깜빡 거리는 오류 증상이 있습니다.
이를 dismiss() 사용시 해당 오류가 발생하지 않아 dismiss로 구현했습니다.
![white](https://github.com/user-attachments/assets/64d3c12e-e46d-4ba4-b0dc-fb6278583964)

#### 2. 화면 전환은 누가 책임져야 할까
화면 전환은 뷰나 뷰모델이 둘다 책임질 수 있을 것 같아여.
view에서 책임진다면 viewModel의 Output에 destination을 설정하면되고 (단, output관찰을 view에서 할 때 살짝 까다로울수있음)
viewModel에서 책임진다면 viewModel에게 NavigationRouter를 전달해주면 되겠네요!
정답은 없는 것 같습니다. 추후 논의 후 다시 결정해봐도 좋을 것 같아요


