### PR TITLE
[Feat/#43] - Home Empty뷰 구현

### DIFF
--- a/SantaManito-iOS/SantaManito-iOS/Data/Service/AuthService.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Data/Service/AuthService.swift
@@ -17,8 +17,9 @@ protocol AuthenticationServiceType {
 
 struct StubAuthenticationService: AuthenticationServiceType {
     func autoLogin() -> AnyPublisher<Void, Error> {
-        Fail(error: AuthError.autoLoginFail).eraseToAnyPublisher()
-//        Just(()).setFailureType(to: Error.self).eraseToAnyPublisher()
+        Just(()).setFailureType(to: Error.self).eraseToAnyPublisher()
+//        Fail(error: AuthError.autoLoginFail).eraseToAnyPublisher()
+//
         
     }
 }

--- a/SantaManito-iOS/SantaManito-iOS/Data/Service/RoomService.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Data/Service/RoomService.swift
@@ -25,7 +25,15 @@ protocol RoomServiceType {
 struct StubRoomService: RoomServiceType {
     
     func fetch() -> AnyPublisher<[RoomInfo], Error> {
-        Just([]).setFailureType(to: Error.self).eraseToAnyPublisher()
+        
+        Future<[RoomInfo],Error> { promise in
+            DispatchQueue.global().asyncAfter(deadline: .now() + 3) {
+                // Simulate success
+                promise(.success([.init(id: "", roomName: "", invitationCode: "", createdAt: "")]))
+            }
+            
+        }
+        .eraseToAnyPublisher()
     }
     
     func fetch(with roomID: String) -> AnyPublisher<RoomDetail, Error> {

--- a/SantaManito-iOS/SantaManito-iOS/Feature/Home/HomeView.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/Home/HomeView.swift
@@ -115,16 +115,17 @@ struct HomeView: View {
     
     var roomsEmptyView: some View {
         VStack(spacing: 24) {
-            
+            Spacer()
             Image(.graphicsSnow)
             
             
             Text("친구들과 산타 마니또를 시작해 볼까?")
                 .font(.medium_14)
                 .foregroundStyle(.smDarkgray)
+            Spacer()
         }
-        .padding(.vertical, 16)
         .frame(maxWidth: .infinity)
+        .frame(height: 240)
         .background(.smLightbg)
         .clipShape(RoundedRectangle(cornerRadius: 10))
         .padding(.horizontal, 16)
@@ -304,6 +305,7 @@ fileprivate struct HomeRoomCell: View {
             RoundedRectangle(cornerRadius: 10)
                 .stroke(Color.smLightgray, lineWidth: 1)
         )
+        .padding(.vertical, 1)
         
         
     }

--- a/SantaManito-iOS/SantaManito-iOS/Feature/Home/HomeView.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/Home/HomeView.swift
@@ -77,33 +77,30 @@ struct HomeView: View {
                         Button {
                             viewModel.send(.refreshButtonDidTap)
                         } label: {
-                            Image(systemName: "arrow.clockwise") // TODO: 에셋 변경
-                                .foregroundStyle(.gray)
+                            Image(.icRefresh)
+                                .rotationEffect(
+                                    Angle(
+                                        degrees:  viewModel.state.isLoading ? 360 : 0
+                                    )
+                                )
+                                .animation(
+                                    viewModel.state.isLoading
+                                    ? .linear(duration: 1).repeatForever(autoreverses: false)
+                                    : .default,
+                                    value: viewModel.state.isLoading
+                                )
                         }
+                        .disabled(viewModel.state.isLoading)
                     }
                     .padding(.top, 40)
                     .padding(.horizontal, 20)
                     
-                    GeometryReader { proxy in
-                        ScrollView(.horizontal, showsIndicators: false) {
-                            HStack {
-                                ForEach(viewModel.state.rooms, id: \.id) { room in
-                                    Button {
-                                        
-                                    } label: {
-                                        HomeRoomCell(room, width: proxy.size.width / 2.4)
-                                    }
-                                    .buttonStyle(ScaleButtonStyle())
-                                    
-                                    
-                                    
-                                    Spacer().frame(width: 15)
-                                }
-                            }
-                            .padding(.horizontal, 20)
-                        }
+                    if viewModel.state.rooms.isEmpty {
+                        roomsEmptyView
+                    } else {
+                        roomsView
                     }
-                    .padding(.top, 20)
+                    
                     
                     Spacer()
                 }
@@ -114,9 +111,48 @@ struct HomeView: View {
             }
         }
         
+    }
+    
+    var roomsEmptyView: some View {
+        VStack(spacing: 24) {
+            
+            Image(.graphicsSnow)
+            
+            
+            Text("친구들과 산타 마니또를 시작해 볼까?")
+                .font(.medium_14)
+                .foregroundStyle(.smDarkgray)
+        }
+        .padding(.vertical, 16)
+        .frame(maxWidth: .infinity)
+        .background(.smLightbg)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .padding(.horizontal, 16)
+        .padding(.top, 20)
         
-        
-        
+    }
+    
+    var roomsView: some View {
+        GeometryReader { proxy in
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack {
+                    ForEach(viewModel.state.rooms, id: \.id) { room in
+                        Button {
+                            
+                        } label: {
+                            HomeRoomCell(room, width: proxy.size.width / 2.4)
+                        }
+                        .buttonStyle(ScaleButtonStyle())
+                        
+                        
+                        
+                        Spacer().frame(width: 15)
+                    }
+                }
+                .padding(.horizontal, 20)
+            }
+        }
+        .padding(.top, 20)
     }
     
 }
@@ -320,5 +356,5 @@ fileprivate struct HomeRoomStateChip: View {
                 HomeViewModel(roomService:
                                 DIContainer.stub.service.roomService,
                               navigationRouter: DIContainer.stub.navigationRouter))
-        .environmentObject(DIContainer.stub)
+    .environmentObject(DIContainer.stub)
 }


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- closed #43

### ✅ 작업한 내용
- 홈 엠티뷰 구현
- refresh 애니메이션 구현

### ❗️PR Point
- refresh 애니메이션은 fetch api가 로딩 중일때 돌아가도록 구현했으며, loading중일때는 refresh버튼 터치가 중복으로 되지 않도록 disabled처리 했습니다.
- overlay ( RoundedRectangle)로 테두리 그릴때, 상위뷰에 padding을 주지 않으면 테두리가 짤려서 보이는 오류가 있습니다.
- 이를 해결하고자 padding을 주었습니다.
- MakeMission뷰 쪽에도 해당 오류 있는 것 같아 추후 수정이 필요해보입니다.

### 📸 스크린샷
![loading](https://github.com/user-attachments/assets/f58789d7-5015-420d-a6b8-2e8d750cd786)
애니메이션 시뮬레이터 봤을 때만 이렇게 보입니다..
