### PR TITLE
Feat/#50 - 서버 점검 팝업 구현 

### DIFF
--- a/SantaManito-iOS/SantaManito-iOS.xcodeproj/project.pbxproj
+++ b/SantaManito-iOS/SantaManito-iOS.xcodeproj/project.pbxproj
@@ -67,7 +67,6 @@
 		D22E9B602C88031C00086549 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D22E9B5F2C88031C00086549 /* Preview Assets.xcassets */; };
 		D22E9B6B2C8803C100086549 /* ObservableObjectSettable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22E9B6A2C8803C100086549 /* ObservableObjectSettable.swift */; };
 		D22E9B732C8803E500086549 /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22E9B722C8803E500086549 /* Service.swift */; };
-		D22E9B752C8803EC00086549 /* Provider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22E9B742C8803EC00086549 /* Provider.swift */; };
 		D22E9B7E2C8804B600086549 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D22E9B7D2C8804B600086549 /* Colors.xcassets */; };
 		D25411A42CA4007A00B87568 /* ManitoWaitingRoomViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26BFA922C919D0900C5CF86 /* ManitoWaitingRoomViewModel.swift */; };
 		D25570E92C8E858A00CCC226 /* EditRoomInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D25570E82C8E858A00CCC226 /* EditRoomInfoView.swift */; };
@@ -185,7 +184,6 @@
 		D22E9B5F2C88031C00086549 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		D22E9B6A2C8803C100086549 /* ObservableObjectSettable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableObjectSettable.swift; sourceTree = "<group>"; };
 		D22E9B722C8803E500086549 /* Service.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Service.swift; sourceTree = "<group>"; };
-		D22E9B742C8803EC00086549 /* Provider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Provider.swift; sourceTree = "<group>"; };
 		D22E9B7D2C8804B600086549 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		D25570E82C8E858A00CCC226 /* EditRoomInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditRoomInfoView.swift; sourceTree = "<group>"; };
 		D25570EC2C8E85CB00CCC226 /* EditRoomInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditRoomInfoViewModel.swift; sourceTree = "<group>"; };
@@ -523,7 +521,6 @@
 			isa = PBXGroup;
 			children = (
 				D22E9B712C8803DD00086549 /* Service */,
-				D22E9B702C8803D800086549 /* Provider */,
 				D22E9B6F2C8803D200086549 /* Entity */,
 				877EA2422C88AE6B0073FFBD /* DTO */,
 			);
@@ -538,14 +535,6 @@
 				874017B12CA29FE20096E847 /* MyPage */,
 			);
 			path = Entity;
-			sourceTree = "<group>";
-		};
-		D22E9B702C8803D800086549 /* Provider */ = {
-			isa = PBXGroup;
-			children = (
-				D22E9B742C8803EC00086549 /* Provider.swift */,
-			);
-			path = Provider;
 			sourceTree = "<group>";
 		};
 		D22E9B712C8803DD00086549 /* Service */ = {
@@ -937,7 +926,6 @@
 				874017CD2CA7EC7A0096E847 /* EditRoomViewType.swift in Sources */,
 				874017A42CA1AB610096E847 /* RoomDetailResponse.swift in Sources */,
 				D276B6082C8AB64B00230FA2 /* Font.swift in Sources */,
-				D22E9B752C8803EC00086549 /* Provider.swift in Sources */,
 				D268794C2CABB5CA0025A611 /* CreateRoomRequest.swift in Sources */,
 				877CA0A22C94304B00D23193 /* SplashView.swift in Sources */,
 				D229FE822CA7D39600979421 /* SMNetworkError.swift in Sources */,

--- a/SantaManito-iOS/SantaManito-iOS/App/DIContainer.swift
+++ b/SantaManito-iOS/SantaManito-iOS/App/DIContainer.swift
@@ -14,7 +14,7 @@ final class DIContainer: ObservableObject {
     var service: ServiceType
     var navigationRouter: NavigationRoutableType
     
-    fileprivate init(
+    private init(
         service: ServiceType,
         navigationRouter: NavigationRoutableType = NavigationRouter()
     ) {
@@ -26,12 +26,6 @@ final class DIContainer: ObservableObject {
 }
 
 extension DIContainer {
-    
-    static var `default`: DIContainer {
-        DIContainer(service: StubService()) // TODO: 실제 service로 변경 필요
-    }
-    
-    static var stub: DIContainer {
-        return .init(service: StubService())
-    }
+    static let `default` = DIContainer(service: StubService()) // TODO: 실제 service로 변경 필요
+    static let stub = DIContainer(service: StubService())
 }

--- a/SantaManito-iOS/SantaManito-iOS/App/SantaManito_iOSApp.swift
+++ b/SantaManito-iOS/SantaManito-iOS/App/SantaManito_iOSApp.swift
@@ -15,7 +15,7 @@ struct SantaManito_iOSApp: App {
     
     var body: some Scene {
         WindowGroup {
-            SplashView(viewModel: .init(authService: container.service.authService))
+            SplashView(viewModel: .init(authService: container.service.authService, remoteConfigService: container.service.remoteConfigService))
                 .environmentObject(container)
             //TestView()
         }

--- a/SantaManito-iOS/SantaManito-iOS/Data/Provider/Provider.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Data/Provider/Provider.swift
@@ -1,8 +1,0 @@
-//
-//  Provider.swift
-//  SantaManito-iOS
-//
-//  Created by 류희재 on 9/4/24.
-//
-
-import Foundation

--- a/SantaManito-iOS/SantaManito-iOS/Data/Service/RemoteConfigService.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Data/Service/RemoteConfigService.swift
@@ -102,6 +102,14 @@ struct StubRemoteConfigService: RemoteConfigServiceType {
     }
     
     func getServerCheckMessage() -> AnyPublisher<String, RemoteConfigError> {
-        Just("익일 오전 7시까지 서버 점검이 진행돼.\n내일 다시 만나자!").setFailureType(to: RemoteConfigError.self).eraseToAnyPublisher()
+        
+        Future<String, RemoteConfigError> { promise in
+            DispatchQueue.global().asyncAfter(deadline: .now() + 2) {
+                promise(.success("익일 오전 7시까지 서버 점검이 진행돼.\n내일 다시 만나자!"))
+            }
+        }
+        .eraseToAnyPublisher()
+
+        //        Just("익일 오전 7시까지 서버 점검이 진행돼.\n내일 다시 만나자!").setFailureType(to: RemoteConfigError.self).eraseToAnyPublisher()
     }
 }

--- a/SantaManito-iOS/SantaManito-iOS/Data/Service/RemoteConfigService.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Data/Service/RemoteConfigService.swift
@@ -94,3 +94,14 @@ extension FirebaseRemoteConfigService: RemoteConfigServiceType {
     
 
 }
+
+
+struct StubRemoteConfigService: RemoteConfigServiceType {
+    func getServerCheck() -> AnyPublisher<Bool, RemoteConfigError> {
+        Just(true).setFailureType(to: RemoteConfigError.self).eraseToAnyPublisher()
+    }
+    
+    func getServerCheckMessage() -> AnyPublisher<String, RemoteConfigError> {
+        Just("익일 오전 7시까지 서버 점검이 진행돼.\n내일 다시 만나자!").setFailureType(to: RemoteConfigError.self).eraseToAnyPublisher()
+    }
+}

--- a/SantaManito-iOS/SantaManito-iOS/Data/Service/Service.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Data/Service/Service.swift
@@ -14,7 +14,8 @@ protocol ServiceType {
     var editRoomService: EditRoomServiceType { get }
     var enterRoomService: EnterRoomServiceType { get }
     var matchRoomService: MatchRoomServiceType { get }
-    var pushNotificationService: PushNotificationServiceType { get set }
+    var pushNotificationService: PushNotificationServiceType { get }
+    var remoteConfigService: RemoteConfigServiceType { get }
 }
 
 //class Service: ServiceType {
@@ -30,6 +31,10 @@ protocol ServiceType {
 //  }
 //}
 
+class Service {
+    
+}
+
 
 class StubService: ServiceType {
     
@@ -40,5 +45,6 @@ class StubService: ServiceType {
     var enterRoomService: EnterRoomServiceType = StubEnterRoomService()
     var matchRoomService: MatchRoomServiceType = StubMatchRoomService()
     var pushNotificationService: PushNotificationServiceType = StubPushNotificationService()
+    var remoteConfigService: RemoteConfigServiceType = StubRemoteConfigService()
     
 }

--- a/SantaManito-iOS/SantaManito-iOS/Feature/Splash/SplashView.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/Splash/SplashView.swift
@@ -34,6 +34,13 @@ struct SplashView: View {
         .onAppear {
             viewModel.send(.onAppear)
         }
+        .smAlert(
+            isPresented:
+                viewModel.state.serverCheckAlert.isPresented,
+            title: viewModel.state.serverCheckAlert.message,
+            primaryButton: ("확인 후 앱 닫기", {
+                exit(0)
+            }))
             
     }
         
@@ -68,6 +75,6 @@ struct SplashView: View {
 }
 
 #Preview {
-    SplashView(viewModel: SplashViewModel(authService: DIContainer.stub.service.authService))
+    SplashView(viewModel: SplashViewModel(authService: DIContainer.stub.service.authService, remoteConfigService: DIContainer.stub.service.remoteConfigService))
         .environmentObject(DIContainer.stub)
 }

--- a/SantaManito-iOS/SantaManito-iOS/Feature/Splash/SplashViewModel.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/Splash/SplashViewModel.swift
@@ -5,6 +5,7 @@
 //  Created by 장석우 on 9/13/24.
 //
 
+import Foundation
 import Combine
 
 class SplashViewModel: ObservableObject {
@@ -17,6 +18,7 @@ class SplashViewModel: ObservableObject {
     
     
     struct State {
+        var serverCheckAlert: (isPresented: Bool, message: String) = (false, "서버 점검 시간입니다")
         var desination: Destination = .splash
         
         enum Destination {
@@ -29,6 +31,7 @@ class SplashViewModel: ObservableObject {
     //MARK: - Dependency
     
     var authService: AuthenticationServiceType
+    var remoteConfigService: RemoteConfigServiceType
     
     //MARK: - Properties
     
@@ -37,20 +40,40 @@ class SplashViewModel: ObservableObject {
 
     //MARK: - Init
     
-    init(authService: AuthenticationServiceType) {
+    init(
+        authService: AuthenticationServiceType,
+        remoteConfigService: RemoteConfigServiceType
+    ) {
         self.authService = authService
+        self.remoteConfigService = remoteConfigService
     }
     
     //MARK: - Methods
     
     func send(_ action: Action) {
+        weak var owner = self
+        guard let owner else { return }
         switch action {
         case .onAppear:
+            
             authService.autoLogin()
+                .receive(on: DispatchQueue.main)
                 .map { State.Destination.main }
                 .catch { _ in Just(State.Destination.onboarding) }
-                .assign(to: \.state.desination, on: self)
+                .assign(to: \.state.desination, on: owner)
                 .store(in: cancelBag)
+            
+            remoteConfigService.getServerCheck()
+                .filter { $0 }
+                .map { _ in }
+                .flatMap(remoteConfigService.getServerCheckMessage)
+                .receive(on: DispatchQueue.main)
+                .catch { _ in Empty() }
+                .map { (true, $0 ) }
+                .assign(to: \.state.serverCheckAlert, on: owner)
+                .store(in: cancelBag)
+            
+
         }
     }
 }


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- closed #50

### ✅ 작업한 내용
- 서버 점검 팝업 구현했습니다.

### ❗️PR Point
#### 자동로그인과 서버점검을 병렬적으로 호출했습니다.
- splash에선 자동로그인과 서버점검 팝업 두 api를 호출합니다.
- api의 우선순위는 서버점검이 더 높다고 생각해요(자동로그인 성공하더라도 서버점검하면 block해야 하기 때문)
- 따라서 서버점검 통과후 flatMap으로 자동로그인 api를 호출하려 했으나, 병렬적으로 호출했습니다.
그 이유는 아래와 같습니다.

**직렬적(서버점검 api 이후 자동로그인 api 호출)**
- 장점: 우선순위가 명확해짐
- 단점: 서버 점검시간이 아닐 때에도 api 호출을 하기에 유저 홈화면 진입 시점이 늦춰질 수 있음

**병렬적(서버점검과 자동로그인 독립적으로 호출)**
- 장점: 유저가 홈화면 진입시점 빠름
- 단점: 순서가 꼬일 수 있다는 문제 (자동로그인이 더 빨리 응답올 경우)
- 단점이 단점이 아닌 이유: 자동로그인이 응답이 더 빨라서 홈화면 진입하더라도, 서버점검 팝업이 화면 전체를 막기에 홈화면 진입하더라도 유저를 block 할 수 있음.

따라서 병렬적 방법을 택했습니다.

### 📸 스크린샷
![servercheck](https://github.com/user-attachments/assets/d5260ba0-e9e8-44c2-a6f3-256c0d5b1463)

