### PR TITLE
[Chore] #77 - struct static -> 구조체 싱글톤으로 변경

### DIFF
--- a/SantaManito-iOS/SantaManito-iOS/Data/Entity/Room/RoomDetail.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Data/Entity/Room/RoomDetail.swift
@@ -21,7 +21,7 @@ struct RoomDetail: Hashable {
     
     
     var isHost: Bool {
-        UserDefaultsService.userID == creatorID
+        UserDefaultsService.shared.userID == creatorID
     }
     
     // 오늘부터 만료일까지 (한국 날짜 기준)

--- a/SantaManito-iOS/SantaManito-iOS/Data/Service/UserDefaultsService.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Data/Service/UserDefaultsService.swift
@@ -13,26 +13,32 @@ enum UserDefaultKey: String, CaseIterable {
 }
 
 protocol UserDefaultsServiceType {
-    static var userID: String { get set }
-    static var accessToken: String { get set }
-}
-
-struct UserDefaultsService: UserDefaultsServiceType {
-    @UserDefault<String>(key: .userID, defaultValue: "") static var userID: String
-    @UserDefault<String>(key: .accessToken, defaultValue: "") static var accessToken: String
-}
-
-
-struct StubUserDefaultsService: UserDefaultsServiceType {
-    static var userID: String = ""
-    static var accessToken: String = ""
+    var userID: String { get set }
+    var accessToken: String { get set }
+    func removeAll()
 }
 
 extension UserDefaultsServiceType {
-    static func reset() {
+    func removeAll() {
         UserDefaultKey.allCases
             .forEach {
                 UserDefaults.standard.removeObject(forKey: $0.rawValue)
             }
     }
 }
+
+
+struct UserDefaultsService: UserDefaultsServiceType {
+    static let shared = UserDefaultsService()
+    private init() { }
+    
+    @UserDefault<String>(key: .userID, defaultValue: "") var userID: String
+    @UserDefault<String>(key: .accessToken, defaultValue: "") var accessToken: String
+}
+
+
+struct StubUserDefaultsService: UserDefaultsServiceType {
+    var userID: String = ""
+    var accessToken: String = ""
+}
+

--- a/SantaManito-iOS/SantaManito-iOS/Feature/MatchRoom/ViewModel/FinishViewModel.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/MatchRoom/ViewModel/FinishViewModel.swift
@@ -54,7 +54,7 @@ class FinishViewModel: ObservableObject {
         var members: [Member] { roomInfo.members }
             
         var member: Member {
-            guard let 내가마니또인멤버Index = roomInfo.members.firstIndex(where: { $0.manitto?.id == UserDefaultsService.userID})
+            guard let 내가마니또인멤버Index = roomInfo.members.firstIndex(where: { $0.manitto?.id == UserDefaultsService.shared.userID})
             else { return .init(santa: .stub1) }
             return roomInfo.members[내가마니또인멤버Index]
         }
@@ -66,8 +66,8 @@ class FinishViewModel: ObservableObject {
     
     //MARK: Dependency
     
-    private var roomService: RoomServiceType
-    private var navigationRouter: NavigationRoutableType
+    private let roomService: RoomServiceType
+    private let navigationRouter: NavigationRoutableType
     
     //MARK: Init
     

--- a/SantaManito-iOS/SantaManito-iOS/Feature/MatchRoom/ViewModel/MatchingResultViewModel.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/MatchRoom/ViewModel/MatchingResultViewModel.swift
@@ -29,7 +29,7 @@ class MatchingResultViewModel: ObservableObject {
             }
         }
         fileprivate var member: Member {
-            guard let 내가마니또인멤버Index = roomInfo.members.firstIndex(where: { $0.manitto?.id == UserDefaultsService.userID})
+            guard let 내가마니또인멤버Index = roomInfo.members.firstIndex(where: { $0.manitto?.id == UserDefaultsService.shared.userID})
             else { return .init(santa: .stub1) }
             return roomInfo.members[내가마니또인멤버Index]
         }

--- a/SantaManito-iOS/SantaManito-iOS/Feature/MyPage/EditUsername/EditUsernameViewModel.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/MyPage/EditUsername/EditUsernameViewModel.swift
@@ -26,7 +26,7 @@ final class EditUsernameViewModel: ObservableObject {
     private let navigationRouter: NavigationRoutableType
     private let windowRouter: WindowRoutableType
     private let userService: UserServiceType
-    private let userDefaultsService: UserDefaultsServiceType.Type
+    private let userDefaultsService: UserDefaultsServiceType
     
     @Published private(set) var state = State()
     @Published var username: String = ""
@@ -37,7 +37,7 @@ final class EditUsernameViewModel: ObservableObject {
     //MARK: - Init
     
     init(userService: UserServiceType,
-         userDefaultsService: UserDefaultsServiceType.Type = UserDefaultsService.self,
+         userDefaultsService: UserDefaultsServiceType = UserDefaultsService.shared,
          navigationRouter: NavigationRoutableType,
          windowRouter: WindowRoutableType
     ) {
@@ -85,7 +85,7 @@ final class EditUsernameViewModel: ObservableObject {
                 .catch { _ in Empty() }
                 .receive(on: DispatchQueue.main)
                 .sink { _ in
-                    owner.userDefaultsService.reset()
+                    owner.userDefaultsService.removeAll()
                     owner.windowRouter.switch(to: .splash)
                     owner.navigationRouter.popToRootView()
                 }

--- a/SantaManito-iOS/SantaManito-iOS/Feature/Onboarding/OnboardingViewModel.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/Onboarding/OnboardingViewModel.swift
@@ -60,7 +60,7 @@ final class OnboardingViewModel: ObservableObject {
     
     private let appService: AppServiceType
     private let authService: AuthenticationServiceType
-    private let userDefaultsService: UserDefaultsServiceType.Type
+    private var userDefaultsService: UserDefaultsServiceType
     private var windowRouter: WindowRoutableType
     
     //MARK: - Properties
@@ -75,7 +75,7 @@ final class OnboardingViewModel: ObservableObject {
     init(
         appService: AppServiceType,
         authService: AuthenticationServiceType,
-        userDefaultsService: UserDefaultsServiceType.Type = UserDefaultsService.self,
+        userDefaultsService: UserDefaultsServiceType = UserDefaultsService.shared,
         windowRouter: WindowRoutableType
     ) {
         self.appService = appService
@@ -113,7 +113,7 @@ final class OnboardingViewModel: ObservableObject {
                     .sink { auth in
                         owner.userDefaultsService.userID = auth.userID
                         owner.userDefaultsService.accessToken = auth.accessToken
-                        owner.windowRouter.switch(to: .main) 
+                        owner.windowRouter.switch(to: .main)
                     }
                     .store(in: cancelBag)
             }

--- a/SantaManito-iOS/SantaManito-iOS/Feature/Splash/SplashViewModel.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/Splash/SplashViewModel.swift
@@ -26,7 +26,7 @@ class SplashViewModel: ObservableObject {
     
     private let appService: AppServiceType
     private let authService: AuthenticationServiceType
-    private let userDefaultsService: UserDefaultsServiceType.Type
+    private var userDefaultsService: UserDefaultsServiceType
     private let remoteConfigService: RemoteConfigServiceType
     private(set) var windowRouter: WindowRoutableType
     
@@ -41,7 +41,7 @@ class SplashViewModel: ObservableObject {
         appService: AppServiceType,
         remoteConfigService: RemoteConfigServiceType,
         authService: AuthenticationServiceType,
-        userDefaultsService: UserDefaultsServiceType.Type = UserDefaultsService.self,
+        userDefaultsService: UserDefaultsServiceType = UserDefaultsService.shared,
         windowRouter: WindowRoutableType
     ) {
         self.appService = appService

--- a/SantaManito-iOS/SantaManito-iOS/Networks/Foundation/APIConstants.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Networks/Foundation/APIConstants.swift
@@ -30,7 +30,7 @@ extension APIConstants{
     static var hasTokenHeader: Dictionary<String,String> {
         return [
             contentType: applicationJSON,
-            auth : "Bearer " + UserDefaultsService.accessToken
+            auth : "Bearer " + UserDefaultsService.shared.accessToken
         ]
     }
 }


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- closed #77

### ✅ 작업한 내용
- AS IS: struct static 
- TO BE: struct 싱글톤 구조

### ❗️PR Point
#### 왜 struct static를 사용하지 않고 싱글톤 구조를 택했나요
- 타입을 주입시켜줘야하기에 프로젝트 통일성에서 벗어난다고 생각
- 프로퍼티가 생길때마다 static한 변수(userID, accesToken, ... etc) 가 프로젝트에 많이 생기는 것이 관리하기 어려울 것이라 생각
- 해당 변수를 하나의 static 인스턴스인 shared에 보관하는 것이 더 관리에 용이하다고 생각

**AS IS**
- `static` userID
- `static` accessToken

**To Be**
- `static` shared
  - userID
  - accessToken
 
#### 왜 싱글톤을 class 가 아닌 struct로 만들었나요?
userID 나 accessToken 싱글톤안에 일반적인 저장프로퍼티로 관리해야한다면 무조건 class로 만들어야 했을 것임.
복사할때 동일한 메모리를 참조해야 하니.
단 UserDefaultsService는 UserDefault라는 프로퍼티 래퍼만을 지니고 있는 특수한 케이스

UserDefault 프로퍼티 래퍼는 내부적으로 UserDefaults.standard에서 값을 read/write하기에 이미 싱글톤 구조임.
따라서 UserDefaultService가 서로 다른 인스턴스 실제 값은 모두 UserDefaults.standard에서 가져오기에 문제 없음!

apple은 class vs struct에선 스택 메모리 관리 측면에서 struct를 권장하기에 struct로 구현함!


