### PR TITLE
[Fix] #102 - exit API -> history API로 변경

### DIFF
--- a/SantaManito-iOS/SantaManito-iOS/Feature/MatchRoom/ViewModel/FinishViewModel.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/MatchRoom/ViewModel/FinishViewModel.swift
@@ -108,7 +108,7 @@ class FinishViewModel: ObservableObject {
         case .alert(.exitRoom):
             state.exitRoomAlertIsPresented = false
             
-            roomService.exitRoom(with: state.roomInfo.id)
+            roomService.deleteHistoryRoom(with: state.roomInfo.id)
                 .catch { _ in Empty() }
                 .receive(on: RunLoop.main)
                 .sink(receiveValue: { [weak self] _ in

--- a/SantaManito-iOS/SantaManito-iOS/Feature/Splash/SplashView.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/Splash/SplashView.swift
@@ -46,8 +46,8 @@ struct SplashView: View {
             isPresented:
                 viewModel.state.serverCheckAlert.isPresented,
             title: viewModel.state.serverCheckAlert.message,
-            primaryButton: ("확인 후 앱 닫기", {
-                exit(0)
+            primaryButton: ("확인", {
+                viewModel.send(.alert(.confirm))
             })
         )
             

--- a/SantaManito-iOS/SantaManito-iOS/Feature/Splash/SplashViewModel.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/Splash/SplashViewModel.swift
@@ -14,12 +14,17 @@ class SplashViewModel: ObservableObject {
     
     enum Action {
         case onAppear
+        case alert(Alert)
     }
     
     
     struct State {
         var mustUpdateAlertIsPresented: Bool = false
         var serverCheckAlert: (isPresented: Bool, message: String) = (false, "서버 점검 시간입니다")
+    }
+    
+    enum Alert {
+        case confirm
     }
     
     //MARK: - Dependency
@@ -57,6 +62,7 @@ class SplashViewModel: ObservableObject {
         weak var owner = self
         guard let owner else { return }
         switch action {
+            
         case .onAppear:
             
             appService.isLatestVersion()
@@ -95,7 +101,8 @@ class SplashViewModel: ObservableObject {
                     
                 }
                 .store(in: cancelBag)
-
+        case .alert(.confirm):
+            state.serverCheckAlert.isPresented = false 
             
 
         }


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- closed #102

### ✅ 작업한 내용
- exit api 가 아닌 history api로 변경

### ❗️PR Point
- alert에 대한 액션을 받는 로직은 Tca에서 Alert 액션 받는 형식처럼 구현했습니다.

