### PR TITLE
[Feat/#106] - 앰플리튜드 온보딩, 홈, 입장하기, 설정 텍소노미를 적용한다.

### DIFF
--- a/SantaManito-iOS/SantaManito-iOS.xcodeproj/project.pbxproj
+++ b/SantaManito-iOS/SantaManito-iOS.xcodeproj/project.pbxproj
@@ -49,6 +49,11 @@
 		877D52022D743E2700FE8317 /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877D52012D743E2700FE8317 /* Analytics.swift */; };
 		877D52042D74437F00FE8317 /* AmplitudeAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877D52032D74437F00FE8317 /* AmplitudeAnalytics.swift */; };
 		877D52062D74A99F00FE8317 /* AnalyticsTaxonomy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877D52052D74A99F00FE8317 /* AnalyticsTaxonomy.swift */; };
+		877D520F2D74C1E400FE8317 /* SplashTaxonomy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877D520E2D74C1E400FE8317 /* SplashTaxonomy.swift */; };
+		877D52112D74C21A00FE8317 /* OnboadringTaxonomy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877D52102D74C21A00FE8317 /* OnboadringTaxonomy.swift */; };
+		877D52132D74C32300FE8317 /* HomeTaxonomy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877D52122D74C32300FE8317 /* HomeTaxonomy.swift */; };
+		877D52152D757B2C00FE8317 /* EnterRoomTaxonomy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877D52142D757B2C00FE8317 /* EnterRoomTaxonomy.swift */; };
+		877D52172D757B7500FE8317 /* MyPageTaxonomy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877D52162D757B7500FE8317 /* MyPageTaxonomy.swift */; };
 		877EA2322C889DCB0073FFBD /* ButtonStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877EA2312C889DCB0073FFBD /* ButtonStyles.swift */; };
 		877EA2392C88AA8A0073FFBD /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877EA2382C88AA8A0073FFBD /* OnboardingView.swift */; };
 		877EA23B2C88AAC10073FFBD /* DIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877EA23A2C88AAC10073FFBD /* DIContainer.swift */; };
@@ -188,6 +193,11 @@
 		877D52012D743E2700FE8317 /* Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
 		877D52032D74437F00FE8317 /* AmplitudeAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmplitudeAnalytics.swift; sourceTree = "<group>"; };
 		877D52052D74A99F00FE8317 /* AnalyticsTaxonomy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsTaxonomy.swift; sourceTree = "<group>"; };
+		877D520E2D74C1E400FE8317 /* SplashTaxonomy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashTaxonomy.swift; sourceTree = "<group>"; };
+		877D52102D74C21A00FE8317 /* OnboadringTaxonomy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboadringTaxonomy.swift; sourceTree = "<group>"; };
+		877D52122D74C32300FE8317 /* HomeTaxonomy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTaxonomy.swift; sourceTree = "<group>"; };
+		877D52142D757B2C00FE8317 /* EnterRoomTaxonomy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnterRoomTaxonomy.swift; sourceTree = "<group>"; };
+		877D52162D757B7500FE8317 /* MyPageTaxonomy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageTaxonomy.swift; sourceTree = "<group>"; };
 		877EA2312C889DCB0073FFBD /* ButtonStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonStyles.swift; sourceTree = "<group>"; };
 		877EA2382C88AA8A0073FFBD /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		877EA23A2C88AAC10073FFBD /* DIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DIContainer.swift; sourceTree = "<group>"; };
@@ -325,6 +335,7 @@
 			children = (
 				874017BD2CA3EF290096E847 /* MyPage */,
 				874017BE2CA3EF2F0096E847 /* EditUsername */,
+				877D52162D757B7500FE8317 /* MyPageTaxonomy.swift */,
 			);
 			path = MyPage;
 			sourceTree = "<group>";
@@ -395,6 +406,7 @@
 			children = (
 				877CA0A12C94304B00D23193 /* SplashView.swift */,
 				877CA0A32C94305200D23193 /* SplashViewModel.swift */,
+				877D520E2D74C1E400FE8317 /* SplashTaxonomy.swift */,
 			);
 			path = Splash;
 			sourceTree = "<group>";
@@ -431,6 +443,7 @@
 			children = (
 				D22E9B5A2C88031A00086549 /* HomeView.swift */,
 				879829042C9827B200A863EC /* HomeViewModel.swift */,
+				877D52122D74C32300FE8317 /* HomeTaxonomy.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -440,6 +453,7 @@
 			children = (
 				877EA2382C88AA8A0073FFBD /* OnboardingView.swift */,
 				87D797A32C9454BF003BA602 /* OnboardingViewModel.swift */,
+				877D52102D74C21A00FE8317 /* OnboadringTaxonomy.swift */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -838,6 +852,7 @@
 			children = (
 				D26BFA8A2C91986100C5CF86 /* ViewModel */,
 				D26BFA892C91985C00C5CF86 /* View */,
+				877D52142D757B2C00FE8317 /* EnterRoomTaxonomy.swift */,
 			);
 			path = EnterRoom;
 			sourceTree = "<group>";
@@ -1051,6 +1066,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				87873BF62CB2E30800E368BF /* AuthEntity.swift in Sources */,
+				877D520F2D74C1E400FE8317 /* SplashTaxonomy.swift in Sources */,
 				D25411A42CA4007A00B87568 /* ManitoWaitingRoomViewModel.swift in Sources */,
 				D2BC1AA12C90A26B00CB32B8 /* CheckRoomInfoView.swift in Sources */,
 				87873BE42CAFF2E200E368BF /* Version.swift in Sources */,
@@ -1065,6 +1081,7 @@
 				877CA0A62C94305A00D23193 /* CancelBag.swift in Sources */,
 				874017B92CA2B0020096E847 /* User.swift in Sources */,
 				D229FE842CA7D70C00979421 /* APIConstants.swift in Sources */,
+				877D52132D74C32300FE8317 /* HomeTaxonomy.swift in Sources */,
 				D229FE862CA7D98400979421 /* BaseService.swift in Sources */,
 				877EA23B2C88AAC10073FFBD /* DIContainer.swift in Sources */,
 				D22E9B6B2C8803C100086549 /* ObservableObjectSettable.swift in Sources */,
@@ -1086,6 +1103,7 @@
 				D2BC1A922C90101E00CB32B8 /* EditMissionView.swift in Sources */,
 				87873BF32CB2E2A100E368BF /* AuthResponse.swift in Sources */,
 				D2A8F6212CA1172100810BCF /* FinishView.swift in Sources */,
+				877D52112D74C21A00FE8317 /* OnboadringTaxonomy.swift in Sources */,
 				87873BF82CB2E71800E368BF /* UserDefaultsService.swift in Sources */,
 				D22E9B592C88031A00086549 /* SantaManito_iOSApp.swift in Sources */,
 				D26879382CAA7BE40025A611 /* NetworkResponse.swift in Sources */,
@@ -1097,6 +1115,7 @@
 				877EA2322C889DCB0073FFBD /* ButtonStyles.swift in Sources */,
 				D28568B22CAD21800044C231 /* Config.swift in Sources */,
 				87C06E5A2C9EA5FE00F03637 /* Device.swift in Sources */,
+				877D52152D757B2C00FE8317 /* EnterRoomTaxonomy.swift in Sources */,
 				D26879482CABB3A80025A611 /* GenericResponse.swift in Sources */,
 				D26879432CAB8DA30025A611 /* NetworkLogHandler.swift in Sources */,
 				871D87482CBD05C40050858A /* RoomStateFactory.swift in Sources */,
@@ -1121,6 +1140,7 @@
 				87C06E612C9EADE700F03637 /* NavigationDestination.swift in Sources */,
 				D26BFA8E2C91987900C5CF86 /* EnterRoomViewModel.swift in Sources */,
 				874017CD2CA7EC7A0096E847 /* EditRoomViewType.swift in Sources */,
+				877D52172D757B7500FE8317 /* MyPageTaxonomy.swift in Sources */,
 				874017A42CA1AB610096E847 /* RoomDetailDTO.swift in Sources */,
 				871D873D2CB8F0560050858A /* MemberResponse.swift in Sources */,
 				D276B6082C8AB64B00230FA2 /* Font.swift in Sources */,

--- a/SantaManito-iOS/SantaManito-iOS/Core/Analytics/Analytics.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Core/Analytics/Analytics.swift
@@ -14,7 +14,6 @@ protocol Analyzable {
 
 final class Analytics {
     static let shared = Analytics()
-    
     private init() { }
 }
 

--- a/SantaManito-iOS/SantaManito-iOS/Feature/EnterRoom/EnterRoomTaxonomy.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/EnterRoom/EnterRoomTaxonomy.swift
@@ -1,0 +1,22 @@
+//
+//  EnterRoomTaxonomy.swift
+//  SantaManito-iOS
+//
+//  Created by 장석우 on 3/3/25.
+//
+
+import Foundation
+
+extension AnalyticsTaxonomy {
+    static let inviteCode = AnalyticsTaxonomy(
+        tag: "입장하기_초대코드입력_닉네임입력",
+        tagEng: "onboarding_name",
+        type: .page
+    )
+    
+    static let inviteCodeEnterBtn = AnalyticsTaxonomy(
+        tag: "입장하기_입장하기버튼_약관동의",
+        tagEng: "onboarding_personal_information",
+        type: .button
+    )
+}

--- a/SantaManito-iOS/SantaManito-iOS/Feature/EnterRoom/EnterRoomTaxonomy.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/EnterRoom/EnterRoomTaxonomy.swift
@@ -9,14 +9,14 @@ import Foundation
 
 extension AnalyticsTaxonomy {
     static let inviteCode = AnalyticsTaxonomy(
-        tag: "입장하기_초대코드입력_닉네임입력",
-        tagEng: "onboarding_name",
+        tag: "입장하기_초대코드입력",
+        tagEng: "invite_code",
         type: .page
     )
     
     static let inviteCodeEnterBtn = AnalyticsTaxonomy(
-        tag: "입장하기_입장하기버튼_약관동의",
-        tagEng: "onboarding_personal_information",
+        tag: "입장하기_입장하기버튼",
+        tagEng: "invite_code_enter_btn",
         type: .button
     )
 }

--- a/SantaManito-iOS/SantaManito-iOS/Feature/EnterRoom/View/EnterRoomView.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/EnterRoom/View/EnterRoomView.swift
@@ -91,6 +91,9 @@ struct EnterRoomView: View {
             }
             .padding(.horizontal, 16)
         }
+        .onAppear {
+            viewModel.send(action: .onAppear)
+        }
         
     }
     

--- a/SantaManito-iOS/SantaManito-iOS/Feature/EnterRoom/ViewModel/EnterRoomViewModel.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/EnterRoom/ViewModel/EnterRoomViewModel.swift
@@ -14,6 +14,7 @@ class EnterRoomViewModel: ObservableObject {
     //MARK: Action, State
     
     enum Action {
+        case onAppear
         case enterButtonDidTap
     }
     struct State {
@@ -23,7 +24,7 @@ class EnterRoomViewModel: ObservableObject {
     
     //MARK: Dependency
     
-    private var roomService: RoomServiceType // 임시의
+    private var roomService: RoomServiceType 
     private var navigationRouter: NavigationRoutableType
     
     //MARK: Init
@@ -55,7 +56,10 @@ class EnterRoomViewModel: ObservableObject {
     
     func send(action: Action) {
         switch action {
+        case .onAppear:
+            Analytics.shared.track(.inviteCode)
         case .enterButtonDidTap:
+            Analytics.shared.track(.inviteCodeEnterBtn)
             roomService.enterRoom(at: inviteCode)
                 .receive(on: RunLoop.main)
                 .mapError { [weak self] error in

--- a/SantaManito-iOS/SantaManito-iOS/Feature/Home/HomeTaxonomy.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/Home/HomeTaxonomy.swift
@@ -1,0 +1,17 @@
+//
+//  HomeTaxonomy.swift
+//  SantaManito-iOS
+//
+//  Created by 장석우 on 3/3/25.
+//
+
+import Foundation
+
+extension AnalyticsTaxonomy {
+    static let home = AnalyticsTaxonomy(
+        tag: "홈_메인",
+        tagEng: "home",
+        type: .page
+    )
+}
+

--- a/SantaManito-iOS/SantaManito-iOS/Feature/Home/HomeViewModel.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/Home/HomeViewModel.swift
@@ -65,9 +65,10 @@ class HomeViewModel: ObservableObject {
         guard let owner else { return }
         
         switch action {
-            
-        case .onAppear, .refreshButtonDidTap:
-            
+        case .onAppear:
+            Analytics.shared.track(.home)
+            send(.refreshButtonDidTap)
+        case .refreshButtonDidTap:
             roomService.getEnteredRooms()
                 .receive(on: RunLoop.main)
                 .assignLoading(to: \.state.isLoading, on: owner)

--- a/SantaManito-iOS/SantaManito-iOS/Feature/MyPage/EditUsername/EditUsernameView.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/MyPage/EditUsername/EditUsernameView.swift
@@ -130,8 +130,8 @@ struct EditUsernameView: View {
         .loading(viewModel.state.isLoading)
         .smAlert(isPresented: viewModel.state.isDeleteAccountAlertPresented,
                  title: "탈퇴하면 추억이 담긴 마니또 내역을\n다시 확인할 수 없어. 그래도 괜찮아?",
-                 primaryButton: ("탈퇴하기", {viewModel.send(.alertDeleteButtonDidTap)}),
-                 secondaryButton: ("머무르기", { viewModel.send(.alertDismissDidTap)}))
+                 primaryButton: ("탈퇴하기", {viewModel.send(.alert(.deleteButtonDidTap))}),
+                 secondaryButton: ("머무르기", { viewModel.send(.alert(.stayButtonDidTap))}))
         
         
     }

--- a/SantaManito-iOS/SantaManito-iOS/Feature/MyPage/EditUsername/EditUsernameViewModel.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/MyPage/EditUsername/EditUsernameViewModel.swift
@@ -14,8 +14,12 @@ final class EditUsernameViewModel: ObservableObject {
         case onAppear
         case doneButtonDidTap
         case deleteAccountButtonDidTap
-        case alertDeleteButtonDidTap
-        case alertDismissDidTap
+        case alert(Alert)
+        
+        enum Alert {
+            case deleteButtonDidTap
+            case stayButtonDidTap
+        }
     }
     
     struct State {
@@ -60,6 +64,7 @@ final class EditUsernameViewModel: ObservableObject {
         
         switch action {
         case .onAppear:
+            Analytics.shared.track(.nameEdit)
             userService.getUser(with: userDefaultsService.userID)
                 .receive(on: RunLoop.main)
                 .assignLoading(to: \.state.isLoading, on: owner)
@@ -72,6 +77,7 @@ final class EditUsernameViewModel: ObservableObject {
                 .store(in: cancelBag)
             
         case .doneButtonDidTap:
+            Analytics.shared.track(.nameEditCompleteBtn)
             userService.editUsername(with: username)
                 .receive(on: RunLoop.main)
                 .assignLoading(to: \.state.isLoading, on: owner)
@@ -81,10 +87,11 @@ final class EditUsernameViewModel: ObservableObject {
                 }
                 .store(in: cancelBag)
         case .deleteAccountButtonDidTap:
+            Analytics.shared.track(.nameEditWithdrawalBtn)
             state.isDeleteAccountAlertPresented = true
-        case .alertDismissDidTap:
-            state.isDeleteAccountAlertPresented = false
-        case .alertDeleteButtonDidTap:
+            Analytics.shared.track(.withdrawalPopup)
+        case .alert(.deleteButtonDidTap):
+            Analytics.shared.track(.withdrawalPopupWithdrawalBtn)
             state.isDeleteAccountAlertPresented = false
             userService.deleteAccount()
                 .receive(on: RunLoop.main)
@@ -97,6 +104,9 @@ final class EditUsernameViewModel: ObservableObject {
                     owner.navigationRouter.popToRootView()
                 }
                 .store(in: cancelBag)
+        case .alert(.stayButtonDidTap):
+            Analytics.shared.track(.withdrawalPopupStayBtn)
+            state.isDeleteAccountAlertPresented = false
         }
     }
     

--- a/SantaManito-iOS/SantaManito-iOS/Feature/MyPage/MyPage/MyPageView.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/MyPage/MyPage/MyPageView.swift
@@ -69,6 +69,9 @@ struct MyPageView: View {
         .sheet(isPresented: $viewModel.state.isPresentedWebView.isPresented)  {
             SMWebView(url: viewModel.state.isPresentedWebView.url)
         }
+        .onAppear {
+            viewModel.send(.onAppear)
+        }
        
         
         

--- a/SantaManito-iOS/SantaManito-iOS/Feature/MyPage/MyPage/MyPageViewModel.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/MyPage/MyPage/MyPageViewModel.swift
@@ -10,6 +10,7 @@ import Foundation
 class MyPageViewModel: ObservableObject {
     
     enum Action {
+        case onAppear
         case cellDidTap(MyPageItem)
     }
     
@@ -27,9 +28,12 @@ class MyPageViewModel: ObservableObject {
     
     func send(_ action: Action) {
         switch action {
+        case .onAppear:
+            Analytics.shared.track(.setting)
         case let .cellDidTap(item):
             switch item {
             case .editUsername:
+                Analytics.shared.track(.settingNameEdit)
                 navigationRouter.push(to: .editUsername)
             
             case .inquiry, .termsOfUse, .privacyPolicy:

--- a/SantaManito-iOS/SantaManito-iOS/Feature/MyPage/MyPageTaxonomy.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/MyPage/MyPageTaxonomy.swift
@@ -1,0 +1,59 @@
+//
+//  MyPageTaxonomy.swift
+//  SantaManito-iOS
+//
+//  Created by 장석우 on 3/3/25.
+//
+
+import Foundation
+
+extension AnalyticsTaxonomy {
+    static let setting = AnalyticsTaxonomy(
+        tag: "설정목록",
+        tagEng: "setting",
+        type: .page
+    )
+
+    static let settingNameEdit = AnalyticsTaxonomy(
+        tag: "설정목록_이름수정",
+        tagEng: "setting_name_edit",
+        type: .button
+    )
+
+    static let nameEdit = AnalyticsTaxonomy(
+        tag: "이름수정",
+        tagEng: "name_edit",
+        type: .page
+    )
+
+    static let nameEditCompleteBtn = AnalyticsTaxonomy(
+        tag: "이름수정_완료버튼",
+        tagEng: "name_edit_complete_btn",
+        type: .button
+    )
+
+    static let nameEditWithdrawalBtn = AnalyticsTaxonomy(
+        tag: "이름수정_탈퇴버튼",
+        tagEng: "name_edit_withdrawal_btn",
+        type: .button
+    )
+
+    static let withdrawalPopup = AnalyticsTaxonomy(
+        tag: "탈퇴모달",
+        tagEng: "withdrawal_popup",
+        type: .modal
+    )
+
+    static let withdrawalPopupWithdrawalBtn = AnalyticsTaxonomy(
+        tag: "탈퇴모달_탈퇴하기버튼",
+        tagEng: "withdrawal_popup_withdrawal_btn",
+        type: .button
+    )
+
+    static let withdrawalPopupStayBtn = AnalyticsTaxonomy(
+        tag: "탈퇴모달_머무르기버튼",
+        tagEng: "withdrawal_popup_stay_btn",
+        type: .button
+    )
+}
+

--- a/SantaManito-iOS/SantaManito-iOS/Feature/Onboarding/OnboadringTaxonomy.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/Onboarding/OnboadringTaxonomy.swift
@@ -1,0 +1,22 @@
+//
+//  OnboadringTaxonomy.swift
+//  SantaManito-iOS
+//
+//  Created by 장석우 on 3/3/25.
+//
+
+import Foundation
+
+extension AnalyticsTaxonomy {
+    static let onboardingName = AnalyticsTaxonomy(
+        tag: "온보딩_닉네임입력",
+        tagEng: "onboarding_name",
+        type: .page
+    )
+    
+    static let onboardingPersonalInformation = AnalyticsTaxonomy(
+        tag: "온보딩_약관동의",
+        tagEng: "onboarding_personal_information",
+        type: .page
+    )
+}

--- a/SantaManito-iOS/SantaManito-iOS/Feature/Onboarding/OnboardingView.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/Onboarding/OnboardingView.swift
@@ -100,8 +100,14 @@ struct OnboardingView: View {
                         switch viewModel.state.step {
                         case .nickname:
                             nicknameView
+                                .onAppear {
+                                    viewModel.send(.onAppear(.nickname))
+                                }
                         case .agreement:
                             agreementView
+                                .onAppear {
+                                    viewModel.send(.onAppear(.agreement))
+                                }
                         }
                     }
                     .overlay(

--- a/SantaManito-iOS/SantaManito-iOS/Feature/Onboarding/OnboardingViewModel.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/Onboarding/OnboardingViewModel.swift
@@ -40,6 +40,7 @@ final class OnboardingViewModel: ObservableObject {
     
     enum Action {
         // step 1, 2
+        case onAppear(State.Step)
         case bottomButtonDidTap
         
         // step 2
@@ -103,6 +104,11 @@ final class OnboardingViewModel: ObservableObject {
         guard let owner else { return }
         
         switch action {
+        case .onAppear(let step):
+            switch step {
+            case .nickname: Analytics.shared.track(.onboardingName)
+            case .agreement: Analytics.shared.track(.onboardingPersonalInformation)
+            }
         case .bottomButtonDidTap:
             switch state.step {
             case .nickname:

--- a/SantaManito-iOS/SantaManito-iOS/Feature/Splash/SplashTaxonomy.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/Splash/SplashTaxonomy.swift
@@ -1,0 +1,16 @@
+//
+//  SplashTaxonomy.swift
+//  SantaManito-iOS
+//
+//  Created by 장석우 on 3/3/25.
+//
+
+import Foundation
+
+extension AnalyticsTaxonomy {
+    static let splash = AnalyticsTaxonomy(
+        tag: "스플래시",
+        tagEng: "splash",
+        type: .page
+    )
+}

--- a/SantaManito-iOS/SantaManito-iOS/Feature/Splash/SplashViewModel.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/Splash/SplashViewModel.swift
@@ -64,7 +64,7 @@ class SplashViewModel: ObservableObject {
         switch action {
             
         case .onAppear:
-            
+            Analytics.shared.track(.splash)
             appService.isLatestVersion()
                 .receive(on: RunLoop.main)
                 .sink { isLatestVersion in


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- closed #106

### ✅ 작업한 내용
- 온보딩, 홈, 입장하기, 설정 텍소노미를 적용

### ❗️PR Point
- home .onAppear가 불필요하게 호출되는 경우가 있음.
- 회원탈퇴시 화면 전환: **"회원 탈퇴뷰 -> 스플래시 -> 온보딩"** 임.
- 디버깅 결과: **"회원 탈퇴뷰 -> 스플래시 ->  `홈 onAppear()` ->온보딩"** 
- SwiftUI @State과 관련된 이슈로 추정함.
- 유저에게 홈뷰가 보이진 않지만 내부 로직을 살펴보면 좋을듯

