### PR TITLE
Feat/#112 - 방입장 텍소노미 적용

### DIFF
--- a/SantaManito-iOS/SantaManito-iOS.xcodeproj/project.pbxproj
+++ b/SantaManito-iOS/SantaManito-iOS.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		874017CD2CA7EC7A0096E847 /* EditRoomViewType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874017CC2CA7EC7A0096E847 /* EditRoomViewType.swift */; };
 		874296212D7437D8001531AA /* AmplitudeSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 874296202D7437D8001531AA /* AmplitudeSwift */; };
 		8742BCFE2CFB0C16009D258A /* FinishViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8742BCFD2CFB0C16009D258A /* FinishViewModelTests.swift */; };
+		8777CF772D7A0063008C5DF6 /* MakeRoomTaxonomy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8777CF762D7A0063008C5DF6 /* MakeRoomTaxonomy.swift */; };
 		8779D8182CB8CDBD00B61DEA /* Member.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8779D8172CB8CDBD00B61DEA /* Member.swift */; };
 		877CA0712C8AB3DE00D23193 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877CA0702C8AB3DE00D23193 /* LoadingView.swift */; };
 		877CA0732C8C4C5C00D23193 /* SMView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877CA0722C8C4C5C00D23193 /* SMView.swift */; };
@@ -176,6 +177,7 @@
 		874017CA2CA7E6970096E847 /* SMPasteBoard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SMPasteBoard.swift; sourceTree = "<group>"; };
 		874017CC2CA7EC7A0096E847 /* EditRoomViewType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditRoomViewType.swift; sourceTree = "<group>"; };
 		8742BCFD2CFB0C16009D258A /* FinishViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinishViewModelTests.swift; sourceTree = "<group>"; };
+		8777CF762D7A0063008C5DF6 /* MakeRoomTaxonomy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MakeRoomTaxonomy.swift; sourceTree = "<group>"; };
 		8779D8172CB8CDBD00B61DEA /* Member.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Member.swift; sourceTree = "<group>"; };
 		877CA0702C8AB3DE00D23193 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		877CA0722C8C4C5C00D23193 /* SMView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SMView.swift; sourceTree = "<group>"; };
@@ -799,6 +801,7 @@
 			children = (
 				D25570E72C8E857D00CCC226 /* ViewModel */,
 				D25570E62C8E857900CCC226 /* View */,
+				8777CF762D7A0063008C5DF6 /* MakeRoomTaxonomy.swift */,
 			);
 			path = MakeRoom;
 			sourceTree = "<group>";
@@ -1100,6 +1103,7 @@
 				877EA23F2C88AB930073FFBD /* AuthService.swift in Sources */,
 				877D52042D74437F00FE8317 /* AmplitudeAnalytics.swift in Sources */,
 				879829092C9EA54B00A863EC /* BaseView.swift in Sources */,
+				8777CF772D7A0063008C5DF6 /* MakeRoomTaxonomy.swift in Sources */,
 				D2BC1A922C90101E00CB32B8 /* EditMissionView.swift in Sources */,
 				87873BF32CB2E2A100E368BF /* AuthResponse.swift in Sources */,
 				D2A8F6212CA1172100810BCF /* FinishView.swift in Sources */,

--- a/SantaManito-iOS/SantaManito-iOS/Feature/EnterRoom/EnterRoomTaxonomy.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/EnterRoom/EnterRoomTaxonomy.swift
@@ -19,4 +19,34 @@ extension AnalyticsTaxonomy {
         tagEng: "invite_code_enter_btn",
         type: .button
     )
+    
+    static let roomManittoList = AnalyticsTaxonomy(
+        tag: "마니또방_목록",
+        tagEng: "room_manitto_list",
+        type: .page
+    )
+    
+    static let roomEditBtn = AnalyticsTaxonomy(
+        tag: "마니또방_수정하기버튼",
+        tagEng: "room_edit_btn",
+        type: .button
+    )
+    
+    static let roomStartBtn = AnalyticsTaxonomy(
+        tag: "마니또방_바로매칭시작하기버튼",
+        tagEng: "room_start_btn",
+        type: .button
+    )
+    
+    static let roomCodeCopyBtn = AnalyticsTaxonomy(
+        tag: "마니또방_초대코드복사버튼",
+        tagEng: "room_code_copy_btn",
+        type: .button
+    )
+    
+    static let roomRefreshBtn = AnalyticsTaxonomy(
+        tag: "마니또방_새로고침버튼",
+        tagEng: "room_refresh_btn",
+        type: .button
+    )
 }

--- a/SantaManito-iOS/SantaManito-iOS/Feature/EnterRoom/ViewModel/ManitoWaitingRoomViewModel.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/EnterRoom/ViewModel/ManitoWaitingRoomViewModel.swift
@@ -55,7 +55,11 @@ class ManitoWaitingRoomViewModel: ObservableObject {
         guard let owner else { return }
         
         switch action {
-        case .onAppear, .refreshButtonDidTap:
+        case .onAppear:
+            Analytics.shared.track(.roomManittoList)
+            send(action: .refreshButtonDidTap)
+        case .refreshButtonDidTap:
+            Analytics.shared.track(.roomRefreshBtn)
             roomService.getRoomInfo(with: state.roomDetail.id)
                 .receive(on: RunLoop.main)
                 .assignLoading(to: \.state.isLoading, on: owner)
@@ -64,12 +68,15 @@ class ManitoWaitingRoomViewModel: ObservableObject {
                 .store(in: cancelBag)
             
         case .copyInviteCodeDidTap:
+            Analytics.shared.track(.roomCodeCopyBtn)
             SMPasteBoard.paste(with: state.roomDetail.invitationCode)
             
         case .matchingButtonDidTap:
+            Analytics.shared.track(.roomStartBtn)
             navigationRouter.push(to: .matchRoom(roomID: state.roomDetail.id))
             
         case .editButtonDidTap:
+            Analytics.shared.track(.roomEditBtn)
             navigationRouter.push(to: .editRoom(viewType: .editMode(roomID: state.roomDetail.id, info: state.roomDetail.toMakeRoomInfo())))
         case .backButtonDidTap:
             navigationRouter.popToRootView()

--- a/SantaManito-iOS/SantaManito-iOS/Feature/MakeRoom/MakeRoomTaxonomy.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/MakeRoom/MakeRoomTaxonomy.swift
@@ -1,0 +1,23 @@
+//
+//  MakeRoomTaxonomy.swift
+//  SantaManito-iOS
+//
+//  Created by 장석우 on 3/7/25.
+//
+
+import Foundation
+
+extension AnalyticsTaxonomy {
+    
+    static let roomEdit = AnalyticsTaxonomy(
+        tag: "마니또방_방정보수정",
+        tagEng: "room_edit",
+        type: .page
+    )
+    
+    static let roomEditCompleteBtn = AnalyticsTaxonomy(
+        tag: "마니또방_방정보수정_수정완료버튼",
+        tagEng: "room_edit_complete_btn",
+        type: .button
+    )
+}

--- a/SantaManito-iOS/SantaManito-iOS/Feature/MakeRoom/ViewModel/EditRoomInfoViewModel.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/MakeRoom/ViewModel/EditRoomInfoViewModel.swift
@@ -108,7 +108,10 @@ final class EditRoomInfoViewModel: ObservableObject {
         
         switch action {
         case .onAppear:
-            return
+            if case .editMode = viewType {
+                Analytics.shared.track(.roomEdit)
+            }
+            
         case .increaseDuedate:
             if state.canIncreaseDays { roomInfo.totalDurationDays += 1 }
             
@@ -133,6 +136,10 @@ final class EditRoomInfoViewModel: ObservableObject {
             navigationRouter.push(to: .makeMission(roomInfo: roomInfo))
             
         case .editButtonDidTap:
+            if case .editMode = viewType {
+                Analytics.shared.track(.roomEditCompleteBtn)
+            }
+            
             guard let roomID = viewType.roomID else { return }
             roomService.editRoomInfo(with: roomID, info: roomInfo)
                 .receive(on: RunLoop.main)

--- a/SantaManito-iOS/SantaManito-iOS/Feature/MyPage/MyPage/MyPageViewModel.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/MyPage/MyPage/MyPageViewModel.swift
@@ -33,7 +33,7 @@ class MyPageViewModel: ObservableObject {
         case let .cellDidTap(item):
             switch item {
             case .editUsername:
-                Analytics.shared.track(.settingNameEdit)
+                Analytics.shared.track(.settingNameEditBtn)
                 navigationRouter.push(to: .editUsername)
             
             case .inquiry, .termsOfUse, .privacyPolicy:

--- a/SantaManito-iOS/SantaManito-iOS/Feature/MyPage/MyPageTaxonomy.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/MyPage/MyPageTaxonomy.swift
@@ -14,9 +14,9 @@ extension AnalyticsTaxonomy {
         type: .page
     )
 
-    static let settingNameEdit = AnalyticsTaxonomy(
-        tag: "설정목록_이름수정",
-        tagEng: "setting_name_edit",
+    static let settingNameEditBtn = AnalyticsTaxonomy(
+        tag: "설정목록_이름수정버튼",
+        tagEng: "setting_name_edit_btn",
         type: .button
     )
 


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- closed #112

### ✅ 작업한 내용
태그 | 태그eng | type |  채널
-- | -- | -- | --
마니또방_목록 | room_manitto_list | page | APP
마니또방_수정하기버튼 | room_edit_btn | button | APP
마니또방_바로매칭시작하기버튼 | room_start_btn | button | APP
마니또방_초대코드복사버튼 | room_code_copy_btn | button | APP
마니또방_새로고침버튼 | room_refresh_btn | button | APP
마니또방_방정보수정 | room_edit | page | APP
마니또방_방정보수정_수정완료버튼 | room_edit_complete_btn | button | APP



### ❗️PR Point
- 기본적인 텍소노미는 EnterRoomTaxonomy지만
- 방 편집은 EditRoom 공통 뷰모델을 사용하기에 MakeRoomTaxonomy에도 추가했습니다.

