### PR TITLE
[Fix] #130 매칭 결과 이전 플로우에서의 메모리 누수 해결하기 

### DIFF
--- a/SantaManito-iOS/SantaManito-iOS.xcodeproj/xcshareddata/xcschemes/SantaManito-iOS.xcscheme
+++ b/SantaManito-iOS/SantaManito-iOS.xcodeproj/xcshareddata/xcschemes/SantaManito-iOS.xcscheme
@@ -46,6 +46,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      disablePerformanceAntipatternChecker = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -62,6 +63,23 @@
             ReferencedContainer = "container:SantaManito-iOS.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <AdditionalOptions>
+         <AdditionalOption
+            key = "MallocStackLogging"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+         <AdditionalOption
+            key = "PrefersMallocStackLoggingLite"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+         <AdditionalOption
+            key = "MallocScribble"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/SantaManito-iOS/SantaManito-iOS/Core/Extension/Publisher+.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Core/Extension/Publisher+.swift
@@ -18,3 +18,14 @@ extension Publisher {
         )
     }
 }
+
+extension Publisher where Failure == Never {
+    func assign<T: AnyObject>(
+        to keyPath: ReferenceWritableKeyPath<T, Output>,
+        on object: T
+    ) -> AnyCancellable {
+        sink { [weak object] value in
+            object?[keyPath: keyPath] = value
+        }
+    }
+}

--- a/SantaManito-iOS/SantaManito-iOS/Feature/MyPage/EditUsername/EditUsernameViewModel.swift
+++ b/SantaManito-iOS/SantaManito-iOS/Feature/MyPage/EditUsername/EditUsernameViewModel.swift
@@ -74,6 +74,7 @@ final class EditUsernameViewModel: ObservableObject {
             
         case .doneButtonDidTap:
             Analytics.shared.track(.nameEditCompleteBtn)
+            
             performTask(
                 loadingKeyPath: \.state.isLoading,
                 operation: { try await self.userService.editUsername(with: self.username) },
@@ -112,8 +113,4 @@ final class EditUsernameViewModel: ObservableObject {
             .assign(to: \.state.doneButtonDisabled, on: self)
             .store(in: cancelBag)
     }
-    
-    
-    
-        
 }


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- closed #130 

### ✅ 작업한 내용
- 매칭 결과 이전 플로우에서의 (방만들기, 방입장하기, 마이페이지, 온보딩) instrument를 통해 메모리 leak을 확인하고 이를 해결했습니다

### Case1. 방 입장하기 뷰에서 뒤로가기를 눌렀을때 => ⚠️ 67 memory leaks
<img width="782" height="438" alt="image" src="https://github.com/user-attachments/assets/c4fa29ee-2801-47ce-bd18-823a7114cfe3" />

- Combine의 assign(to:on:) 메서드에서 발생하는 강한 참조 순환(Retain Cycle) 발생
- self → cancelBag → AnyCancellable → assign -> self 형태로 순환참조 발생
- 따라서 viewModel이 해제되어도 viewModel 객체가 해제되지 않음


=> 해결방안: custom assign 구현 -> assign을 활용하는 모든 viewModel에서의 메모리 leak 해결
- 기존 assign 메소드의 강한 참조를 해결하고자
    - `[weak object]`: 약한 참조로 캡처 → **메모리 누수 방지**
    - `object?[keyPath: keyPath]`: 옵셔널 체이닝으로 안전한 할당
    - `T: AnyObject`: 클래스 타입만 허용 (참조 타입이어야 weak 참조 가능)
```Swift
extension Publisher where Failure == Never {
    func assign<T: AnyObject>(
        to keyPath: ReferenceWritableKeyPath<T, Output>,
        on object: T
    ) -> AnyCancellable {
        sink { [weak object] value in
            object?[keyPath: keyPath] = value
        }
    }
}
```

### Case2. 이름수정하기 뷰 에러 해결 => ⚠️ 22 memory leaks
<img width="777" height="565" alt="image" src="https://github.com/user-attachments/assets/45723181-443f-4599-88e3-98a7f51c624a" />

- viewModel의 저장 프로퍼티 oldName을 강한 참조하며 문제 발생
- self → cancelBag → AnyCancellable → map클로저
- 따라서 viewModel이 해제되어도 viewModel 객체가 해제되지 않음
```Swift
.map { $0.isEmpty || $0 == self.oldUsername}

// 컴파일러가 실제로 생성하는 코드 (개념적)
.map { [강한캡처_self = self] value in  // 🚨 강한 캡처!
    return value.isEmpty || 강한캡처_self.oldUsername
}
```

=> 해결방안: [weak self] 추가 -> self 약한 참조를 통해 문제 해결
```Swift
private func observe() {
    $username
        .map { $0.isEmpty || $0 == self.oldUsername}
        .assign(to: \.state.doneButtonDisabled, on: self)
        .store(in: cancelBag)
}
```



### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->
